### PR TITLE
*: import listeners and add authz library

### DIFF
--- a/authz/README.md
+++ b/authz/README.md
@@ -1,0 +1,39 @@
+# Credits
+
+Inspired by David's awesome [dkvolume](https://github.com/calavera/dkvolume) and adapted for the authZ api.
+
+# Docker authz extension api.
+
+Go handler to create external authz extensions for Docker.
+
+## Usage
+
+This library is designed to be integrated in your program.
+
+1. Implement the `dkauthz.Plugin` interface.
+2. Initialize a `dkauthz.Handler` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `dkauthz.Handler`.
+
+### Example using TCP sockets:
+
+```go
+  p := MyAuthZPlugin{}
+  h := dkauthz.NewHandler(p)
+  h.ServeTCP("test_plugin", ":8080")
+```
+
+### Example using Unix sockets:
+
+```go
+  p := MyAuthZPlugin{}
+  h := dkauthz.NewHandler(p)
+  h.ServeUnix("root", "test_plugin")
+```
+
+## Full example plugins
+
+- https://github.com/runcom/docker-novolume-plugin
+
+## License
+
+MIT

--- a/authz/api.go
+++ b/authz/api.go
@@ -1,0 +1,130 @@
+package dkauthz
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/docker/docker/pkg/authorization"
+	"github.com/docker/go-plugins-sdk/sdk"
+)
+
+const (
+	defaultContentTypeV1_1        = "application/vnd.docker.plugins.v1.1+json"
+	defaultImplementationManifest = `{"Implements": ["` + authorization.AuthZApiImplements + `"]}`
+
+	activatePath = "/Plugin.Activate"
+	reqPath      = "/" + authorization.AuthZApiRequest
+	resPath      = "/" + authorization.AuthZApiResponse
+)
+
+type Request authorization.Request
+
+type Response authorization.Response
+
+// Plugin represent the interface a plugin must fulfill.
+type Plugin interface {
+	AuthZReq(Request) Response
+	AuthZRes(Request) Response
+}
+
+// Handler forwards requests and responses between the docker daemon and the plugin.
+type Handler struct {
+	plugin Plugin
+	mux    *http.ServeMux
+}
+
+// NewHandler initializes the request handler with a plugin implementation.
+func NewHandler(plugin Plugin) *Handler {
+	h := &Handler{plugin, http.NewServeMux()}
+	h.initMux()
+	return h
+}
+
+func (h *Handler) initMux() {
+	h.mux.HandleFunc(activatePath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", defaultContentTypeV1_1)
+		fmt.Fprintln(w, defaultImplementationManifest)
+	})
+
+	h.handle(reqPath, func(req Request) Response {
+		return h.plugin.AuthZReq(req)
+	})
+
+	h.handle(resPath, func(req Request) Response {
+		return h.plugin.AuthZRes(req)
+	})
+}
+
+type actionHandler func(Request) Response
+
+func (h *Handler) handle(name string, actionCall actionHandler) {
+	h.mux.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
+		req, err := decodeRequest(w, r)
+		if err != nil {
+			return
+		}
+
+		res := actionCall(req)
+
+		encodeResponse(w, res)
+	})
+}
+
+// ServeTCP makes the handler to listen for request in a given TCP address.
+// It also writes the spec file on the right directory for docker to read.
+func (h *Handler) ServeTCP(pluginName, addr string) error {
+	return h.listenAndServe("tcp", addr, pluginName)
+}
+
+// ServeUnix makes the handler to listen for requests in a unix socket.
+// It also creates the socket file on the right directory for docker to read.
+func (h *Handler) ServeUnix(systemGroup, addr string) error {
+	return h.listenAndServe("unix", addr, systemGroup)
+}
+
+func (h *Handler) listenAndServe(proto, addr, group string) error {
+	var (
+		l    net.Listener
+		err  error
+		spec string
+	)
+
+	server := http.Server{
+		Addr:    addr,
+		Handler: h.mux,
+	}
+
+	switch proto {
+	case "tcp":
+		l, spec, err = sdk.NewTCPListener(addr, group)
+	case "unix":
+		l, spec, err = sdk.NewUnixListener(addr, group)
+	}
+
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	if err != nil {
+		return err
+	}
+
+	return server.Serve(l)
+}
+
+func decodeRequest(w http.ResponseWriter, r *http.Request) (req Request, err error) {
+	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+	return
+}
+
+func encodeResponse(w http.ResponseWriter, res Response) {
+	w.Header().Set("Content-Type", defaultContentTypeV1_1)
+	if res.Err != "" {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	json.NewEncoder(w).Encode(res)
+}

--- a/sdk/tcp_listener.go
+++ b/sdk/tcp_listener.go
@@ -6,17 +6,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/pkg/sockets"
+	"github.com/docker/go-connections/sockets"
 )
 
 const (
 	pluginSpecDir = "/etc/docker/plugins"
 )
 
-func newTCPListener(
-	address string,
-	pluginName string,
-) (net.Listener, string, error) {
+func NewTCPListener(address string, pluginName string) (net.Listener, string, error) {
 	listener, err := sockets.NewTCPSocket(address, nil)
 	if err != nil {
 		return nil, "", err

--- a/sdk/unix_listener.go
+++ b/sdk/unix_listener.go
@@ -7,17 +7,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/pkg/sockets"
+	"github.com/docker/go-connections/sockets"
 )
 
 const (
 	pluginSockDir = "/run/docker/plugins"
 )
 
-func newUnixListener(
-	pluginName string,
-	group string,
-) (net.Listener, string, error) {
+func NewUnixListener(pluginName string, group string) (net.Listener, string, error) {
 	path, err := fullSocketAddress(pluginName)
 	if err != nil {
 		return nil, "", err

--- a/sdk/unix_listener_unsupported.go
+++ b/sdk/unix_listener_unsupported.go
@@ -11,9 +11,6 @@ var (
 	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on linux and freebsd")
 )
 
-func newUnixListener(
-	pluginName string,
-	group string,
-) (net.Listener, string, error) {
+func NewUnixListener(pluginName string, group string) (net.Listener, string, error) {
 	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
 }


### PR DESCRIPTION
Thought I'd give a start at this importing the common code under `sdk/` (name suggestions welcome if you don't like it) while thinking about importing the main `api` file. Libraries share so much code right now. It would be good for future plugins libraries to integrate nice here (authN?)

Second commit adds authz library

Signed-off-by: Antonio Murdaca runcom@redhat.com
