### PR TITLE
Add volumes package.

### DIFF
--- a/authz/README.md
+++ b/authz/README.md
@@ -10,15 +10,15 @@ Go handler to create external authz extensions for Docker.
 
 This library is designed to be integrated in your program.
 
-1. Implement the `dkauthz.Plugin` interface.
-2. Initialize a `dkauthz.Handler` with your implementation.
-3. Call either `ServeTCP` or `ServeUnix` from the `dkauthz.Handler`.
+1. Implement the `authz.Plugin` interface.
+2. Initialize a `authz.Handler` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `authz.Handler`.
 
 ### Example using TCP sockets:
 
 ```go
   p := MyAuthZPlugin{}
-  h := dkauthz.NewHandler(p)
+  h := authz.NewHandler(p)
   h.ServeTCP("test_plugin", ":8080")
 ```
 
@@ -26,7 +26,7 @@ This library is designed to be integrated in your program.
 
 ```go
   p := MyAuthZPlugin{}
-  h := dkauthz.NewHandler(p)
+  h := authz.NewHandler(p)
   h.ServeUnix("root", "test_plugin")
 ```
 

--- a/authz/api.go
+++ b/authz/api.go
@@ -1,23 +1,16 @@
-package dkauthz
+package authz
 
 import (
-	"encoding/json"
-	"fmt"
-	"net"
 	"net/http"
-	"os"
 
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/go-plugins-sdk/sdk"
 )
 
 const (
-	defaultContentTypeV1_1        = "application/vnd.docker.plugins.v1.1+json"
-	defaultImplementationManifest = `{"Implements": ["` + authorization.AuthZApiImplements + `"]}`
-
-	activatePath = "/Plugin.Activate"
-	reqPath      = "/" + authorization.AuthZApiRequest
-	resPath      = "/" + authorization.AuthZApiResponse
+	manifest = `{"Implements": ["` + authorization.AuthZApiImplements + `"]}`
+	reqPath  = "/" + authorization.AuthZApiRequest
+	resPath  = "/" + authorization.AuthZApiResponse
 )
 
 type Request authorization.Request
@@ -33,22 +26,17 @@ type Plugin interface {
 // Handler forwards requests and responses between the docker daemon and the plugin.
 type Handler struct {
 	plugin Plugin
-	mux    *http.ServeMux
+	sdk.Handler
 }
 
 // NewHandler initializes the request handler with a plugin implementation.
 func NewHandler(plugin Plugin) *Handler {
-	h := &Handler{plugin, http.NewServeMux()}
+	h := &Handler{plugin, sdk.NewHandler(manifest)}
 	h.initMux()
 	return h
 }
 
 func (h *Handler) initMux() {
-	h.mux.HandleFunc(activatePath, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", defaultContentTypeV1_1)
-		fmt.Fprintln(w, defaultImplementationManifest)
-	})
-
 	h.handle(reqPath, func(req Request) Response {
 		return h.plugin.AuthZReq(req)
 	})
@@ -61,70 +49,14 @@ func (h *Handler) initMux() {
 type actionHandler func(Request) Response
 
 func (h *Handler) handle(name string, actionCall actionHandler) {
-	h.mux.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
-		req, err := decodeRequest(w, r)
-		if err != nil {
+	h.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
+		var req Request
+		if err := sdk.DecodeRequest(w, r, &req); err != nil {
 			return
 		}
 
 		res := actionCall(req)
 
-		encodeResponse(w, res)
+		sdk.EncodeResponse(w, res, res.Err)
 	})
-}
-
-// ServeTCP makes the handler to listen for request in a given TCP address.
-// It also writes the spec file on the right directory for docker to read.
-func (h *Handler) ServeTCP(pluginName, addr string) error {
-	return h.listenAndServe("tcp", addr, pluginName)
-}
-
-// ServeUnix makes the handler to listen for requests in a unix socket.
-// It also creates the socket file on the right directory for docker to read.
-func (h *Handler) ServeUnix(systemGroup, addr string) error {
-	return h.listenAndServe("unix", addr, systemGroup)
-}
-
-func (h *Handler) listenAndServe(proto, addr, group string) error {
-	var (
-		l    net.Listener
-		err  error
-		spec string
-	)
-
-	server := http.Server{
-		Addr:    addr,
-		Handler: h.mux,
-	}
-
-	switch proto {
-	case "tcp":
-		l, spec, err = sdk.NewTCPListener(addr, group)
-	case "unix":
-		l, spec, err = sdk.NewUnixListener(addr, group)
-	}
-
-	if spec != "" {
-		defer os.Remove(spec)
-	}
-	if err != nil {
-		return err
-	}
-
-	return server.Serve(l)
-}
-
-func decodeRequest(w http.ResponseWriter, r *http.Request) (req Request, err error) {
-	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-	}
-	return
-}
-
-func encodeResponse(w http.ResponseWriter, res Response) {
-	w.Header().Set("Content-Type", defaultContentTypeV1_1)
-	if res.Err != "" {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-	json.NewEncoder(w).Encode(res)
 }

--- a/sdk/encoder.go
+++ b/sdk/encoder.go
@@ -1,0 +1,25 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const DefaultContentTypeV1_1 = "application/vnd.docker.plugins.v1.1+json"
+
+// DecodeRequest decodes an http request into a given structure.
+func DecodeRequest(w http.ResponseWriter, r *http.Request, req interface{}) (err error) {
+	if err = json.NewDecoder(r.Body).Decode(req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+	return
+}
+
+// EncodeResponse encodes the given structure into an http response.
+func EncodeResponse(w http.ResponseWriter, res interface{}, err string) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	if err != "" {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	json.NewEncoder(w).Encode(res)
+}

--- a/sdk/handler.go
+++ b/sdk/handler.go
@@ -1,0 +1,74 @@
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+const activatePath = "/Plugin.Activate"
+
+// Handler is the base to create plugin handlers.
+// It initializes connections and sockets to listen to.
+type Handler struct {
+	mux *http.ServeMux
+}
+
+// NewHandler creates a new Handler with an http mux.
+func NewHandler(manifest string) Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(activatePath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+		fmt.Fprintln(w, manifest)
+	})
+
+	return Handler{mux}
+}
+
+// ServeTCP makes the handler to listen for request in a given TCP address.
+// It also writes the spec file on the right directory for docker to read.
+func (h Handler) ServeTCP(pluginName, addr string) error {
+	return h.listenAndServe("tcp", addr, pluginName)
+}
+
+// ServeUnix makes the handler to listen for requests in a unix socket.
+// It also creates the socket file on the right directory for docker to read.
+func (h Handler) ServeUnix(systemGroup, addr string) error {
+	return h.listenAndServe("unix", addr, systemGroup)
+}
+
+// HandleFunc registers a function to handle a request path with.
+func (h Handler) HandleFunc(path string, fn func(w http.ResponseWriter, r *http.Request)) {
+	h.mux.HandleFunc(path, fn)
+}
+
+func (h Handler) listenAndServe(proto, addr, group string) error {
+	var (
+		l    net.Listener
+		err  error
+		spec string
+	)
+
+	server := http.Server{
+		Addr:    addr,
+		Handler: h.mux,
+	}
+
+	switch proto {
+	case "tcp":
+		l, spec, err = newTCPListener(addr, group)
+	case "unix":
+		l, spec, err = newUnixListener(addr, group)
+	}
+
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	if err != nil {
+		return err
+	}
+
+	return server.Serve(l)
+}

--- a/sdk/tcp_listener.go
+++ b/sdk/tcp_listener.go
@@ -13,7 +13,7 @@ const (
 	pluginSpecDir = "/etc/docker/plugins"
 )
 
-func NewTCPListener(address string, pluginName string) (net.Listener, string, error) {
+func newTCPListener(address string, pluginName string) (net.Listener, string, error) {
 	listener, err := sockets.NewTCPSocket(address, nil)
 	if err != nil {
 		return nil, "", err

--- a/sdk/unix_listener.go
+++ b/sdk/unix_listener.go
@@ -14,7 +14,7 @@ const (
 	pluginSockDir = "/run/docker/plugins"
 )
 
-func NewUnixListener(pluginName string, group string) (net.Listener, string, error) {
+func newUnixListener(pluginName string, group string) (net.Listener, string, error) {
 	path, err := fullSocketAddress(pluginName)
 	if err != nil {
 		return nil, "", err

--- a/sdk/unix_listener_unsupported.go
+++ b/sdk/unix_listener_unsupported.go
@@ -11,6 +11,6 @@ var (
 	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on linux and freebsd")
 )
 
-func NewUnixListener(pluginName string, group string) (net.Listener, string, error) {
+func newUnixListener(pluginName string, group string) (net.Listener, string, error) {
 	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
 }

--- a/volume/README.md
+++ b/volume/README.md
@@ -1,0 +1,32 @@
+# Docker volume extension api.
+
+Go handler to create external volume extensions for Docker.
+
+## Usage
+
+This library is designed to be integrated in your program.
+
+1. Implement the `volume.Driver` interface.
+2. Initialize a `volume.Hander` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `volume.Handler`.
+
+### Example using TCP sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  h.ServeTCP("test_volume", ":8080")
+```
+
+### Example using Unix sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  h.ServeUnix("root", "test_volume")
+```
+
+## Full example plugins
+
+- https://github.com/calavera/docker-volume-glusterfs
+- https://github.com/calavera/docker-volume-keywhiz

--- a/volume/api.go
+++ b/volume/api.go
@@ -1,0 +1,90 @@
+package volume
+
+import (
+	"net/http"
+
+	"github.com/docker/go-plugins-sdk/sdk"
+)
+
+const (
+	// DefaultDockerRootDirectory is the default directory where volumes will be created.
+	DefaultDockerRootDirectory = "/var/lib/docker-volumes"
+
+	manifest        = `{"Implements": ["VolumeDriver"]}`
+	createPath      = "/VolumeDriver.Create"
+	remotePath      = "/VolumeDriver.Remove"
+	hostVirtualPath = "/VolumeDriver.Path"
+	mountPath       = "/VolumeDriver.Mount"
+	unmountPath     = "/VolumeDriver.Unmount"
+)
+
+// Request is the structure that docker's requests are deserialized to.
+type Request struct {
+	Name    string
+	Options map[string]string `json:"Opts,omitempty"`
+}
+
+// Response is the strucutre that the plugin's responses are serialized to.
+type Response struct {
+	Mountpoint string
+	Err        string
+}
+
+// Driver represent the interface a driver must fulfill.
+type Driver interface {
+	Create(Request) Response
+	Remove(Request) Response
+	Path(Request) Response
+	Mount(Request) Response
+	Unmount(Request) Response
+}
+
+// Handler forwards requests and responses between the docker daemon and the plugin.
+type Handler struct {
+	driver Driver
+	sdk.Handler
+}
+
+type actionHandler func(Request) Response
+
+// NewHandler initializes the request handler with a driver implementation.
+func NewHandler(driver Driver) *Handler {
+	h := &Handler{driver, sdk.NewHandler(manifest)}
+	h.initMux()
+	return h
+}
+
+func (h *Handler) initMux() {
+	h.handle(createPath, func(req Request) Response {
+		return h.driver.Create(req)
+	})
+
+	h.handle(remotePath, func(req Request) Response {
+		return h.driver.Remove(req)
+	})
+
+	h.handle(hostVirtualPath, func(req Request) Response {
+		return h.driver.Path(req)
+	})
+
+	h.handle(mountPath, func(req Request) Response {
+		return h.driver.Mount(req)
+	})
+
+	h.handle(unmountPath, func(req Request) Response {
+		return h.driver.Unmount(req)
+	})
+}
+
+func (h *Handler) handle(name string, actionCall actionHandler) {
+	h.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
+		var req Request
+		if err := sdk.DecodeRequest(w, r, &req); err != nil {
+			return
+		}
+
+		res := actionCall(req)
+
+		sdk.EncodeResponse(w, res, res.Err)
+	})
+}


### PR DESCRIPTION
- Remove code duplications to share initialization between plugins.
- Remove `dk` prefixes from package names, because the import paths are now self explanatory.

/cc @icecrime, @runcom 

Signed-off-by: David Calavera david.calavera@gmail.com
