### PR TITLE
Allow creating network plugins with global scope

### DIFF
--- a/network/api_test.go
+++ b/network/api_test.go
@@ -15,6 +15,10 @@ type TestDriver struct {
 	Driver
 }
 
+func (t *TestDriver) GetCapabilities() (*CapabilitiesResponse, error) {
+	return &CapabilitiesResponse{Scope:LocalScope}, nil
+}
+
 func (t *TestDriver) CreateNetwork(r *CreateNetworkRequest) error {
 	return nil
 }
@@ -41,6 +45,10 @@ func (t *TestDriver) Leave(r *LeaveRequest) error {
 
 type ErrDriver struct {
 	Driver
+}
+
+func (e *ErrDriver) GetCapabilities() (*CapabilitiesResponse, error) {
+	return nil, fmt.Errorf("I CAN HAZ ERRORZ")
 }
 
 func (e *ErrDriver) CreateNetwork(r *CreateNetworkRequest) error {


### PR DESCRIPTION
Exposes GetCapabilities API so that plugins can choose whether to be global or local scope. Adds a check so that existing plugins that do not implement this function continue to work with local scope.