### PR TITLE
Adds shim layer for writing volume drivers

### DIFF
--- a/volume/shim.go
+++ b/volume/shim.go
@@ -1,0 +1,111 @@
+package volume
+
+import "github.com/docker/docker/volume"
+
+type shimDriver struct {
+	d volume.Driver
+}
+
+// NewHandlerFromVolumeDriver creates a plugin handler from an existing volume
+// driver. This could be used, for instance, by the `local` volume driver built-in
+// to Docker Engine and it would create a plugin from it that maps plugin API calls
+// directly to any volume driver that satifies the volume.Driver interface from
+// Docker Engine.
+func NewHandlerFromVolumeDriver(d volume.Driver) *Handler {
+	return NewHandler(&shimDriver{d})
+}
+
+func (d *shimDriver) Create(req Request) Response {
+	var res Response
+	_, err := d.d.Create(req.Name, req.Options)
+	if err != nil {
+		res.Err = err.Error()
+	}
+	return res
+}
+
+func (d *shimDriver) List(req Request) Response {
+	var res Response
+	ls, err := d.d.List()
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	vols := make([]*Volume, len(ls))
+
+	for _, v := range ls {
+		vol := &Volume{
+			Name:       v.Name(),
+			Mountpoint: v.Path(),
+		}
+		vols = append(vols, vol)
+	}
+	res.Volumes = vols
+	return res
+}
+
+func (d *shimDriver) Get(req Request) Response {
+	var res Response
+	v, err := d.d.Get(req.Name)
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	res.Volume = &Volume{
+		Name:       v.Name(),
+		Mountpoint: v.Path(),
+	}
+	return res
+}
+
+func (d *shimDriver) Remove(req Request) Response {
+	var res Response
+	v, err := d.d.Get(req.Name)
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	if err := d.d.Remove(v); err != nil {
+		res.Err = err.Error()
+	}
+	return res
+}
+
+func (d *shimDriver) Path(req Request) Response {
+	var res Response
+	v, err := d.d.Get(req.Name)
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	res.Mountpoint = v.Path()
+	return res
+}
+
+func (d *shimDriver) Mount(req Request) Response {
+	var res Response
+	v, err := d.d.Get(req.Name)
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	pth, err := v.Mount()
+	if err != nil {
+		res.Err = err.Error()
+	}
+	res.Mountpoint = pth
+	return res
+}
+
+func (d *shimDriver) Unmount(req Request) Response {
+	var res Response
+	v, err := d.d.Get(req.Name)
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	if err := v.Unmount(); err != nil {
+		res.Err = err.Error()
+	}
+	return res
+}

--- a/volume/shim_test.go
+++ b/volume/shim_test.go
@@ -1,0 +1,43 @@
+package volume
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/volume"
+	"github.com/docker/go-connections/sockets"
+)
+
+type testVolumeDriver struct{}
+type testVolume struct{}
+
+func (testVolume) Name() string           { return "" }
+func (testVolume) Path() string           { return "" }
+func (testVolume) Mount() (string, error) { return "", nil }
+func (testVolume) Unmount() error         { return nil }
+func (testVolume) DriverName() string     { return "" }
+
+func (testVolumeDriver) Name() string                                            { return "" }
+func (testVolumeDriver) Create(string, map[string]string) (volume.Volume, error) { return nil, nil }
+func (testVolumeDriver) Remove(volume.Volume) error                              { return nil }
+func (testVolumeDriver) List() ([]volume.Volume, error)                          { return nil, nil }
+func (testVolumeDriver) Get(name string) (volume.Volume, error)                  { return nil, nil }
+
+func TestVolumeDriver(t *testing.T) {
+	h := NewHandlerFromVolumeDriver(testVolumeDriver{})
+	l := sockets.NewInmemSocket("test", 0)
+	go h.Serve(l)
+	defer l.Close()
+
+	client := &http.Client{Transport: &http.Transport{
+		Dial: l.Dial,
+	}}
+
+	resp, err := pluginRequest(client, createPath, Request{Name: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Err != "" {
+		t.Fatalf("error while creating volume: %v", err)
+	}
+}


### PR DESCRIPTION
This allows a plugin writer to not care about the plugin API and rather
focus on the volume driver API from engine.

As an example, engine's built-in `local` driver can operate as a plugin
with no extra effort with this shim layer.