### PR TITLE
Add graphdriver helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ A collection of helper packages to extend Docker Engine in Go
  Network       | [Link](https://docs.docker.com/engine/extend/plugins_network/) | Extend network management
  Volume        | [Link](https://docs.docker.com/engine/extend/plugins_volume/)  | Extend persistent storage
  IPAM          | [Link](https://github.com/docker/libnetwork/blob/master/docs/ipam.md) | Extend IP address management
+ Graph (experimental) | [Link](https://github.com/docker/docker/blob/master/experimental/plugins_graphdriver.md) | Extend image and container fs storage
 
 See the [understand Docker plugins documentation section](https://docs.docker.com/engine/extend/plugins/).

--- a/graphdriver/README.md
+++ b/graphdriver/README.md
@@ -1,0 +1,27 @@
+# Docker volume extension api.
+
+Go handler to create external graphdriver extensions for Docker.
+
+## Usage
+
+This library is designed to be integrated in your program.
+
+1. Implement the `graphdriver.Driver` interface.
+2. Initialize a `graphdriver.Handler` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `graphdriver.Handler`.
+
+### Example using TCP sockets:
+
+```go
+  d := MyGraphDriver{}
+  h := graphdriver.NewHandler(d)
+  h.ServeTCP("test_graph", ":8080")
+```
+
+### Example using Unix sockets:
+
+```go
+  d := MyGraphDriver{}
+  h := graphdriver.NewHandler(d)
+  h.ServeUnix("root", "test_graph")
+```

--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -3,6 +3,8 @@ package graphdriver
 // See https://github.com/docker/docker/blob/master/experimental/plugins_graphdriver.md
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 
@@ -388,4 +390,245 @@ func (h *Handler) initMux() {
 		}
 		sdk.EncodeResponse(w, &DiffSizeResponse{Err: msg, Size: size}, msg)
 	})
+}
+
+func PluginInitRequest(url string, client *http.Client, req InitRequest) (*InitResponse, error) {
+	method := initPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp InitResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginCreateRequest(url string, client *http.Client, req CreateRequest) (*CreateResponse, error) {
+	method := createPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp CreateResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginRemoveRequest(url string, client *http.Client, req RemoveRequest) (*RemoveResponse, error) {
+	method := removePath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp RemoveResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginGetRequest(url string, client *http.Client, req GetRequest) (*GetResponse, error) {
+	method := getPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp GetResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginPutRequest(url string, client *http.Client, req PutRequest) (*PutResponse, error) {
+	method := putPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp PutResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginExistsRequest(url string, client *http.Client, req ExistsRequest) (*ExistsResponse, error) {
+	method := existsPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp ExistsResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginStatusRequest(url string, client *http.Client, req StatusRequest) (*StatusResponse, error) {
+	method := statusPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp StatusResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginGetMetadataRequest(url string, client *http.Client, req GetMetadataRequest) (*GetMetadataResponse, error) {
+	method := getMetadataPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp GetMetadataResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginCleanupRequest(url string, client *http.Client, req CleanupRequest) (*CleanupResponse, error) {
+	method := cleanupPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp CleanupResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginDiffRequest(url string, client *http.Client, req DiffRequest) (*DiffResponse, error) {
+	method := diffPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	return &DiffResponse{Stream: resp.Body}, nil
+}
+
+func PluginChangesRequest(url string, client *http.Client, req ChangesRequest) (*ChangesResponse, error) {
+	method := changesPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp ChangesResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginApplyDiffRequest(url string, client *http.Client, req ApplyDiffRequest) (*ApplyDiffResponse, error) {
+	method := applyDiffPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp ApplyDiffResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func PluginDiffSizeRequest(url string, client *http.Client, req DiffSizeRequest) (*DiffSizeResponse, error) {
+	method := diffSizePath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp DiffSizeResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
 }

--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -392,7 +392,8 @@ func (h *Handler) initMux() {
 	})
 }
 
-func PluginInitRequest(url string, client *http.Client, req InitRequest) (*InitResponse, error) {
+// CallInit is the raw call to the Graphdriver.Init method
+func CallInit(url string, client *http.Client, req InitRequest) (*InitResponse, error) {
 	method := initPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -411,7 +412,8 @@ func PluginInitRequest(url string, client *http.Client, req InitRequest) (*InitR
 	return &vResp, nil
 }
 
-func PluginCreateRequest(url string, client *http.Client, req CreateRequest) (*CreateResponse, error) {
+// CallCreate is the raw call to the Graphdriver.Create method
+func CallCreate(url string, client *http.Client, req CreateRequest) (*CreateResponse, error) {
 	method := createPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -430,7 +432,8 @@ func PluginCreateRequest(url string, client *http.Client, req CreateRequest) (*C
 	return &vResp, nil
 }
 
-func PluginRemoveRequest(url string, client *http.Client, req RemoveRequest) (*RemoveResponse, error) {
+// CallRemove is the raw call to the Graphdriver.Remove method
+func CallRemove(url string, client *http.Client, req RemoveRequest) (*RemoveResponse, error) {
 	method := removePath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -449,7 +452,8 @@ func PluginRemoveRequest(url string, client *http.Client, req RemoveRequest) (*R
 	return &vResp, nil
 }
 
-func PluginGetRequest(url string, client *http.Client, req GetRequest) (*GetResponse, error) {
+// CallGet is the raw call to the Graphdriver.Get method
+func CallGet(url string, client *http.Client, req GetRequest) (*GetResponse, error) {
 	method := getPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -468,7 +472,8 @@ func PluginGetRequest(url string, client *http.Client, req GetRequest) (*GetResp
 	return &vResp, nil
 }
 
-func PluginPutRequest(url string, client *http.Client, req PutRequest) (*PutResponse, error) {
+// CallPut is the raw call to the Graphdriver.Put method
+func CallPut(url string, client *http.Client, req PutRequest) (*PutResponse, error) {
 	method := putPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -487,7 +492,8 @@ func PluginPutRequest(url string, client *http.Client, req PutRequest) (*PutResp
 	return &vResp, nil
 }
 
-func PluginExistsRequest(url string, client *http.Client, req ExistsRequest) (*ExistsResponse, error) {
+// CallExists is the raw call to the Graphdriver.Exists method
+func CallExists(url string, client *http.Client, req ExistsRequest) (*ExistsResponse, error) {
 	method := existsPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -506,7 +512,8 @@ func PluginExistsRequest(url string, client *http.Client, req ExistsRequest) (*E
 	return &vResp, nil
 }
 
-func PluginStatusRequest(url string, client *http.Client, req StatusRequest) (*StatusResponse, error) {
+// CallStatus is the raw call to the Graphdriver.Status method
+func CallStatus(url string, client *http.Client, req StatusRequest) (*StatusResponse, error) {
 	method := statusPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -525,7 +532,8 @@ func PluginStatusRequest(url string, client *http.Client, req StatusRequest) (*S
 	return &vResp, nil
 }
 
-func PluginGetMetadataRequest(url string, client *http.Client, req GetMetadataRequest) (*GetMetadataResponse, error) {
+// CallGetMetadata is the raw call to the Graphdriver.GetMetadata method
+func CallGetMetadata(url string, client *http.Client, req GetMetadataRequest) (*GetMetadataResponse, error) {
 	method := getMetadataPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -544,7 +552,8 @@ func PluginGetMetadataRequest(url string, client *http.Client, req GetMetadataRe
 	return &vResp, nil
 }
 
-func PluginCleanupRequest(url string, client *http.Client, req CleanupRequest) (*CleanupResponse, error) {
+// CallCleanup is the raw call to the Graphdriver.Cleanup method
+func CallCleanup(url string, client *http.Client, req CleanupRequest) (*CleanupResponse, error) {
 	method := cleanupPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -563,7 +572,8 @@ func PluginCleanupRequest(url string, client *http.Client, req CleanupRequest) (
 	return &vResp, nil
 }
 
-func PluginDiffRequest(url string, client *http.Client, req DiffRequest) (*DiffResponse, error) {
+// CallDiff is the raw call to the Graphdriver.Diff method
+func CallDiff(url string, client *http.Client, req DiffRequest) (*DiffResponse, error) {
 	method := diffPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -576,7 +586,8 @@ func PluginDiffRequest(url string, client *http.Client, req DiffRequest) (*DiffR
 	return &DiffResponse{Stream: resp.Body}, nil
 }
 
-func PluginChangesRequest(url string, client *http.Client, req ChangesRequest) (*ChangesResponse, error) {
+// CallChanges is the raw call to the Graphdriver.Changes method
+func CallChanges(url string, client *http.Client, req ChangesRequest) (*ChangesResponse, error) {
 	method := changesPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -595,7 +606,8 @@ func PluginChangesRequest(url string, client *http.Client, req ChangesRequest) (
 	return &vResp, nil
 }
 
-func PluginApplyDiffRequest(url string, client *http.Client, req ApplyDiffRequest) (*ApplyDiffResponse, error) {
+// CallApplyDiff is the raw call to the Graphdriver.ApplyDiff method
+func CallApplyDiff(url string, client *http.Client, req ApplyDiffRequest) (*ApplyDiffResponse, error) {
 	method := applyDiffPath
 	b, err := json.Marshal(req)
 	if err != nil {
@@ -614,7 +626,8 @@ func PluginApplyDiffRequest(url string, client *http.Client, req ApplyDiffReques
 	return &vResp, nil
 }
 
-func PluginDiffSizeRequest(url string, client *http.Client, req DiffSizeRequest) (*DiffSizeResponse, error) {
+// CallDiffSize is the raw call to the Graphdriver.CallDiffSize method
+func CallDiffSize(url string, client *http.Client, req DiffSizeRequest) (*DiffSizeResponse, error) {
 	method := diffSizePath
 	b, err := json.Marshal(req)
 	if err != nil {

--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -1,0 +1,391 @@
+package graphdriver
+
+// See https://github.com/docker/docker/blob/master/experimental/plugins_graphdriver.md
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/docker/go-plugins-helpers/sdk"
+)
+
+const (
+	// DefaultDockerRootDirectory is the default directory where graph drivers will be created.
+	DefaultDockerRootDirectory = "/var/lib/docker/graph"
+
+	manifest        = `{"Implements": ["GraphDriver"]}`
+	initPath        = "/GraphDriver.Init"
+	createPath      = "/GraphDriver.Create"
+	removePath      = "/GraphDriver.Remove"
+	getPath         = "/GraphDriver.Get"
+	putPath         = "/GraphDriver.Put"
+	existsPath      = "/GraphDriver.Exists"
+	statusPath      = "/GraphDriver.Status"
+	getMetadataPath = "/GraphDriver.GetMetadata"
+	cleanupPath     = "/GraphDriver.Cleanup"
+	diffPath        = "/GraphDriver.Diff"
+	changesPath     = "/GraphDriver.Changes"
+	applyDiffPath   = "/GraphDriver.ApplyDiff"
+	diffSizePath    = "/GraphDriver.DiffSize"
+)
+
+// Init
+
+// InitRequest is the structure that docker's init requests are deserialized to.
+type InitRequest struct {
+	Home    string
+	Options map[string]string `json:"Opts,omitempty"`
+}
+
+// InitResponse is the strucutre that docker's init responses are serialized to.
+type InitResponse struct {
+	Err string
+}
+
+// Create
+
+// CreateRequest is the structure that docker's create requests are deserialized to.
+type CreateRequest struct {
+	ID     string
+	Parent string
+}
+
+// CreateResponse is the strucutre that docker's create responses are serialized to.
+type CreateResponse struct {
+	Err string
+}
+
+// Remove
+
+// RemoveRequest is the structure that docker's remove requests are deserialized to.
+type RemoveRequest struct {
+	ID string
+}
+
+// RemoveResponse is the strucutre that docker's remove responses are serialized to.
+type RemoveResponse struct {
+	Err string
+}
+
+// Get
+
+// GetRequest is the structure that docker's get requests are deserialized to.
+type GetRequest struct {
+	ID         string
+	MountLabel string
+}
+
+// GetResponse is the strucutre that docker's remove responses are serialized to.
+type GetResponse struct {
+	Dir string
+	Err string
+}
+
+// Put
+
+// PutRequest is the structure that docker's put requests are deserialized to.
+type PutRequest struct {
+	ID string
+}
+
+// PutResponse is the strucutre that docker's put responses are serialized to.
+type PutResponse struct {
+	Err string
+}
+
+// Exists
+
+// ExistsRequest is the structure that docker's exists requests are deserialized to.
+type ExistsRequest struct {
+	ID string
+}
+
+// ExistsResponse is the structure that docker's exists responses are serialized to.
+type ExistsResponse struct {
+	Exists bool
+}
+
+// Status
+
+// StatusRequest is the structure that docker's status requests are deserialized to.
+type StatusRequest struct{}
+
+// StatusResponse is the structure that docker's status responses are serialized to.
+type StatusResponse struct {
+	Status [][2]string
+}
+
+// GetMetadata
+
+// GetMetadataRequest is the structure that docker's getMetadata requests are deserialized to.
+type GetMetadataRequest struct {
+	ID string
+}
+
+// GetMetadataResponse is the structure that docker's getMetadata responses are serialized to.
+type GetMetadataResponse struct {
+	Metadata map[string]string
+	Err      string
+}
+
+// Cleanup
+
+// CleanupRequest is the structure that docker's cleanup requests are deserialized to.
+type CleanupRequest struct{}
+
+// CleanupResponse is the structure that docker's cleanup responses are serialized to.
+type CleanupResponse struct {
+	Err string
+}
+
+// Diff
+
+// DiffRequest is the structure that docker's diff requests are deserialized to.
+type DiffRequest struct {
+	ID     string
+	Parent string
+}
+
+// DiffResponse is the structure that docker's diff responses are serialized to.
+type DiffResponse struct {
+	Stream io.ReadCloser // TAR STREAM
+}
+
+// Changes
+
+// ChangesRequest is the structure that docker's changes requests are deserialized to.
+type ChangesRequest struct {
+	ID     string
+	Parent string
+}
+
+// ChangesResponse is the structure that docker's changes responses are serialized to.
+type ChangesResponse struct {
+	Changes []Change
+	Err     string
+}
+
+// ChangeKind represents the type of change mage
+type ChangeKind int
+
+const (
+	// Modified is a ChangeKind used when an item has been modified
+	Modified ChangeKind = iota
+	// Added is a ChangeKind used when an item has been added
+	Added
+	// Deleted is a ChangeKind used when an item has been deleted
+	Deleted
+)
+
+// Change is the structure that docker's individual changes are serialized to.
+type Change struct {
+	Path string
+	Kind ChangeKind
+}
+
+// ApplyDiff
+
+// ApplyDiffRequest is the structure that docker's applyDiff requests are deserialized to.
+type ApplyDiffRequest struct {
+	Stream io.Reader // TAR STREAM
+	ID     string
+	Parent string
+}
+
+// ApplyDiffResponse is the structure that docker's applyDiff responses are serialized to.
+type ApplyDiffResponse struct {
+	Size int64
+	Err  string
+}
+
+// DiffSize
+
+// DiffSizeRequest is the structure that docker's diffSize requests are deserialized to.
+type DiffSizeRequest struct {
+	ID     string
+	Parent string
+}
+
+// DiffSizeResponse is the structure that docker's diffSize responses are serialized to.
+type DiffSizeResponse struct {
+	Size int64
+	Err  string
+}
+
+// Driver represent the interface a driver must fulfill.
+type Driver interface {
+	Init(home string, options map[string]string) error
+	Create(id, parent string) error
+	Remove(id string) error
+	Get(id, mountLabel string) (string, error)
+	Put(id string) error
+	Exists(id string) bool
+	Status() [][2]string
+	GetMetadata(id string) (map[string]string, error)
+	Cleanup() error
+	Diff(id, parent string) io.ReadCloser
+	Changes(id, parent string) ([]Change, error)
+	ApplyDiff(id, parent string, archive io.Reader) (int64, error)
+	DiffSize(id, parent string) (int64, error)
+}
+
+// Handler forwards requests and responses between the docker daemon and the plugin.
+type Handler struct {
+	driver Driver
+	sdk.Handler
+}
+
+// NewHandler initializes the request handler with a driver implementation.
+func NewHandler(driver Driver) *Handler {
+	h := &Handler{driver, sdk.NewHandler(manifest)}
+	h.initMux()
+	return h
+}
+
+func (h *Handler) initMux() {
+	h.HandleFunc(initPath, func(w http.ResponseWriter, r *http.Request) {
+		req := InitRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Init(req.Home, req.Options)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &InitResponse{Err: msg}, msg)
+	})
+	h.HandleFunc(createPath, func(w http.ResponseWriter, r *http.Request) {
+		req := CreateRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Create(req.ID, req.Parent)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &CreateResponse{Err: msg}, msg)
+	})
+	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
+		req := RemoveRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Remove(req.ID)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &RemoveResponse{Err: msg}, msg)
+
+	})
+	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+		req := GetRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		dir, err := h.driver.Get(req.ID, req.MountLabel)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &GetResponse{Err: msg, Dir: dir}, msg)
+	})
+	h.HandleFunc(putPath, func(w http.ResponseWriter, r *http.Request) {
+		req := PutRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Put(req.ID)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &PutResponse{Err: msg}, msg)
+	})
+	h.HandleFunc(existsPath, func(w http.ResponseWriter, r *http.Request) {
+		req := ExistsRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		exists := h.driver.Exists(req.ID)
+		sdk.EncodeResponse(w, &ExistsResponse{Exists: exists}, "")
+	})
+	h.HandleFunc(statusPath, func(w http.ResponseWriter, r *http.Request) {
+		status := h.driver.Status()
+		sdk.EncodeResponse(w, &StatusResponse{Status: status}, "")
+	})
+	h.HandleFunc(getMetadataPath, func(w http.ResponseWriter, r *http.Request) {
+		req := GetMetadataRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		metadata, err := h.driver.GetMetadata(req.ID)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &GetMetadataResponse{Err: msg, Metadata: metadata}, msg)
+	})
+	h.HandleFunc(cleanupPath, func(w http.ResponseWriter, r *http.Request) {
+		err := h.driver.Cleanup()
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &CleanupResponse{Err: msg}, msg)
+	})
+	h.HandleFunc(diffPath, func(w http.ResponseWriter, r *http.Request) {
+		req := DiffRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		stream := h.driver.Diff(req.ID, req.Parent)
+		sdk.StreamResponse(w, stream)
+	})
+	h.HandleFunc(changesPath, func(w http.ResponseWriter, r *http.Request) {
+		req := ChangesRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		changes, err := h.driver.Changes(req.ID, req.Parent)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &ChangesResponse{Err: msg, Changes: changes}, msg)
+	})
+	h.HandleFunc(applyDiffPath, func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("id")
+		parent := r.Header.Get("parent")
+		size, err := h.driver.ApplyDiff(id, parent, r.Body)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &ApplyDiffResponse{Err: msg, Size: size}, msg)
+	})
+	h.HandleFunc(diffSizePath, func(w http.ResponseWriter, r *http.Request) {
+		req := DiffRequest{}
+		err := sdk.DecodeRequest(w, r, &req)
+		if err != nil {
+			return
+		}
+		size, err := h.driver.DiffSize(req.ID, req.Parent)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		sdk.EncodeResponse(w, &DiffSizeResponse{Err: msg, Size: size}, msg)
+	})
+}

--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -49,8 +49,9 @@ type InitResponse struct {
 
 // CreateRequest is the structure that docker's create requests are deserialized to.
 type CreateRequest struct {
-	ID     string
-	Parent string
+	ID         string
+	Parent     string
+	MountLabel string
 }
 
 // CreateResponse is the strucutre that docker's create responses are serialized to.

--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -34,7 +34,7 @@ const (
 // InitRequest is the structure that docker's init requests are deserialized to.
 type InitRequest struct {
 	Home    string
-	Options map[string]string `json:"Opts,omitempty"`
+	Options []string `json:"Opts"`
 }
 
 // InitResponse is the strucutre that docker's init responses are serialized to.
@@ -214,7 +214,7 @@ type DiffSizeResponse struct {
 
 // Driver represent the interface a driver must fulfill.
 type Driver interface {
-	Init(home string, options map[string]string) error
+	Init(home string, options []string) error
 	Create(id, parent string) error
 	Remove(id string) error
 	Get(id, mountLabel string) (string, error)

--- a/graphdriver/api_test.go
+++ b/graphdriver/api_test.go
@@ -24,7 +24,7 @@ func TestHandler(t *testing.T) {
 	}}
 
 	// Init
-	init, err := PluginInitRequest(url, client, InitRequest{Home: "foo"})
+	init, err := CallInit(url, client, InitRequest{Home: "foo"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Create
-	create, err := PluginCreateRequest(url, client, CreateRequest{ID: "foo", Parent: "bar"})
+	create, err := CallCreate(url, client, CreateRequest{ID: "foo", Parent: "bar"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Remove
-	remove, err := PluginRemoveRequest(url, client, RemoveRequest{ID: "foo"})
+	remove, err := CallRemove(url, client, RemoveRequest{ID: "foo"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Get
-	get, err := PluginGetRequest(url, client, GetRequest{ID: "foo", MountLabel: "bar"})
+	get, err := CallGet(url, client, GetRequest{ID: "foo", MountLabel: "bar"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Put
-	put, err := PluginPutRequest(url, client, PutRequest{ID: "foo"})
+	put, err := CallPut(url, client, PutRequest{ID: "foo"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Exists
-	exists, err := PluginExistsRequest(url, client, ExistsRequest{ID: "foo"})
+	exists, err := CallExists(url, client, ExistsRequest{ID: "foo"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Status
-	status, err := PluginStatusRequest(url, client, StatusRequest{})
+	status, err := CallStatus(url, client, StatusRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// GetMetadata
-	getMetadata, err := PluginGetMetadataRequest(url, client, GetMetadataRequest{ID: "foo"})
+	getMetadata, err := CallGetMetadata(url, client, GetMetadataRequest{ID: "foo"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Cleanup
-	cleanup, err := PluginCleanupRequest(url, client, CleanupRequest{})
+	cleanup, err := CallCleanup(url, client, CleanupRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Diff
-	_, err = PluginDiffRequest(url, client, DiffRequest{ID: "foo", Parent: "bar"})
+	_, err = CallDiff(url, client, DiffRequest{ID: "foo", Parent: "bar"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// Changes
-	changes, err := PluginChangesRequest(url, client, ChangesRequest{ID: "foo", Parent: "bar"})
+	changes, err := CallChanges(url, client, ChangesRequest{ID: "foo", Parent: "bar"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestHandler(t *testing.T) {
 	// ApplyDiff
 	b := new(bytes.Buffer)
 	stream := bytes.NewReader(b.Bytes())
-	applyDiff, err := PluginApplyDiffRequest(url, client,
+	applyDiff, err := CallApplyDiff(url, client,
 		ApplyDiffRequest{ID: "foo", Parent: "bar", Stream: stream})
 	if err != nil {
 		t.Fatal(err)
@@ -168,7 +168,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	// DiffSize
-	diffSize, err := PluginDiffSizeRequest(url, client, DiffSizeRequest{ID: "foo", Parent: "bar"})
+	diffSize, err := CallDiffSize(url, client, DiffSizeRequest{ID: "foo", Parent: "bar"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/graphdriver/api_test.go
+++ b/graphdriver/api_test.go
@@ -48,7 +48,8 @@ func TestHandler(t *testing.T) {
 	}
 
 	// CreateReadWrite
-	createReadWrite, err := CallCreateReadWrite(url, client, CreateRequest{ID: "foo", Parent: "bar"})
+	createReadWrite, err := CallCreateReadWrite(url, client,
+		CreateRequest{ID: "foo", Parent: "bar", MountLabel: "toto"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/graphdriver/api_test.go
+++ b/graphdriver/api_test.go
@@ -1,0 +1,506 @@
+package graphdriver
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+func TestHandler(t *testing.T) {
+	p := &testPlugin{}
+	h := NewHandler(p)
+	l := sockets.NewInmemSocket("test", 0)
+	go h.Serve(l)
+	defer l.Close()
+
+	client := &http.Client{Transport: &http.Transport{
+		Dial: l.Dial,
+	}}
+
+	// Init
+	init, err := pluginInitRequest(client, InitRequest{Home: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if init.Err != "" {
+		t.Fatalf("got error initialising graph drivers: %v", init.Err)
+	}
+	if p.init != 1 {
+		t.Fatalf("expected init 1, got %d", p.init)
+	}
+
+	// Create
+	create, err := pluginCreateRequest(client, CreateRequest{ID: "foo", Parent: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if create.Err != "" {
+		t.Fatalf("got error creating graph drivers: %v", create.Err)
+	}
+	if p.create != 1 {
+		t.Fatalf("expected create 1, got %d", p.create)
+	}
+
+	// Remove
+	remove, err := pluginRemoveRequest(client, RemoveRequest{ID: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remove.Err != "" {
+		t.Fatalf("got error removing graph drivers: %s", remove.Err)
+	}
+	if p.remove != 1 {
+		t.Fatalf("expected remove 1, got %d", p.remove)
+	}
+
+	// Get
+	get, err := pluginGetRequest(client, GetRequest{ID: "foo", MountLabel: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if get.Err != "" {
+		t.Fatalf("got error getting graph drivers: %s", get.Err)
+	}
+	if p.get != 1 {
+		t.Fatalf("expected get 1, got %d", p.get)
+	}
+
+	// Put
+	put, err := pluginPutRequest(client, PutRequest{ID: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if put.Err != "" {
+		t.Fatalf("got error putting graph drivers: %s", put.Err)
+	}
+	if p.put != 1 {
+		t.Fatalf("expected put 1, got %d", p.put)
+	}
+
+	// Exists
+	exists, err := pluginExistsRequest(client, ExistsRequest{ID: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists.Exists {
+		t.Fatalf("got error testing for existence of graph drivers: %v", exists.Exists)
+	}
+	if p.exists != 1 {
+		t.Fatalf("expected exists 1, got %d", p.exists)
+	}
+
+	// Status
+	status, err := pluginStatusRequest(client, StatusRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Status != nil {
+		t.Fatalf("got error putting graph drivers: %s", status.Status)
+	}
+	if p.status != 1 {
+		t.Fatalf("expected get 1, got %d", p.get)
+	}
+
+	// GetMetadata
+	getMetadata, err := pluginGetMetadataRequest(client, GetMetadataRequest{ID: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getMetadata.Err != "" {
+		t.Fatalf("got error getting metadata for graph drivers: %s", getMetadata.Err)
+	}
+	if p.getMetadata != 1 {
+		t.Fatalf("expected getMetadata 1, got %d", p.getMetadata)
+	}
+
+	// Cleanup
+	cleanup, err := pluginCleanupRequest(client, CleanupRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup.Err != "" {
+		t.Fatalf("got error cleaning graph drivers up: %s", cleanup.Err)
+	}
+	if p.cleanup != 1 {
+		t.Fatalf("expected cleanup 1, got %d", p.cleanup)
+	}
+
+	// Diff
+	_, err = pluginDiffRequest(client, DiffRequest{ID: "foo", Parent: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.diff != 1 {
+		t.Fatalf("expected diff 1, got %d", p.diff)
+	}
+
+	// Changes
+	changes, err := pluginChangesRequest(client, ChangesRequest{ID: "foo", Parent: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changes.Err != "" {
+		t.Fatalf("got error putting graph drivers: %s", changes.Err)
+	}
+	if p.status != 1 {
+		t.Fatalf("expected get 1, got %d", p.get)
+	}
+
+	// ApplyDiff
+	b := new(bytes.Buffer)
+	stream := bytes.NewReader(b.Bytes())
+	applyDiff, err := pluginApplyDiffRequest(client,
+		ApplyDiffRequest{ID: "foo", Parent: "bar", Stream: stream})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applyDiff.Err != "" {
+		t.Fatalf("got error applying diff on graph drivers: %s", applyDiff.Err)
+	}
+	if p.status != 1 {
+		t.Fatalf("expected applyDiff 1, got %d", p.applyDiff)
+	}
+
+	// DiffSize
+	diffSize, err := pluginDiffSizeRequest(client, DiffSizeRequest{ID: "foo", Parent: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diffSize.Err != "" {
+		t.Fatalf("got error getting diff size for graph drivers: %s", diffSize.Err)
+	}
+	if p.diffSize != 1 {
+		t.Fatalf("expected diffSize 1, got %d", p.diffSize)
+	}
+}
+
+func pluginInitRequest(client *http.Client, req InitRequest) (*InitResponse, error) {
+	method := initPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp InitResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginCreateRequest(client *http.Client, req CreateRequest) (*CreateResponse, error) {
+	method := createPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp CreateResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginRemoveRequest(client *http.Client, req RemoveRequest) (*RemoveResponse, error) {
+	method := removePath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp RemoveResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginGetRequest(client *http.Client, req GetRequest) (*GetResponse, error) {
+	method := getPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp GetResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginPutRequest(client *http.Client, req PutRequest) (*PutResponse, error) {
+	method := putPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp PutResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginExistsRequest(client *http.Client, req ExistsRequest) (*ExistsResponse, error) {
+	method := existsPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp ExistsResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginStatusRequest(client *http.Client, req StatusRequest) (*StatusResponse, error) {
+	method := statusPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp StatusResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginGetMetadataRequest(client *http.Client, req GetMetadataRequest) (*GetMetadataResponse, error) {
+	method := getMetadataPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp GetMetadataResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginCleanupRequest(client *http.Client, req CleanupRequest) (*CleanupResponse, error) {
+	method := cleanupPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp CleanupResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginDiffRequest(client *http.Client, req DiffRequest) (*DiffResponse, error) {
+	method := diffPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	return &DiffResponse{Stream: resp.Body}, nil
+}
+
+func pluginChangesRequest(client *http.Client, req ChangesRequest) (*ChangesResponse, error) {
+	method := changesPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp ChangesResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginApplyDiffRequest(client *http.Client, req ApplyDiffRequest) (*ApplyDiffResponse, error) {
+	method := applyDiffPath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp ApplyDiffResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+func pluginDiffSizeRequest(client *http.Client, req DiffSizeRequest) (*DiffSizeResponse, error) {
+	method := diffSizePath
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp DiffSizeResponse
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+type testPlugin struct {
+	init        int
+	create      int
+	remove      int
+	get         int
+	put         int
+	exists      int
+	status      int
+	getMetadata int
+	cleanup     int
+	diff        int
+	changes     int
+	applyDiff   int
+	diffSize    int
+}
+
+var _ Driver = &testPlugin{}
+
+func (p *testPlugin) Init(string, map[string]string) error {
+	p.init++
+	return nil
+}
+
+func (p *testPlugin) Create(string, string) error {
+	p.create++
+	return nil
+}
+
+func (p *testPlugin) Remove(string) error {
+	p.remove++
+	return nil
+}
+
+func (p *testPlugin) Get(string, string) (string, error) {
+	p.get++
+	return "", nil
+}
+
+func (p *testPlugin) Put(string) error {
+	p.put++
+	return nil
+}
+
+func (p *testPlugin) Exists(string) bool {
+	p.exists++
+	return true
+}
+
+func (p *testPlugin) Status() [][2]string {
+	p.status++
+	return nil
+}
+
+func (p *testPlugin) GetMetadata(string) (map[string]string, error) {
+	p.getMetadata++
+	return nil, nil
+}
+
+func (p *testPlugin) Cleanup() error {
+	p.cleanup++
+	return nil
+}
+
+func (p *testPlugin) Diff(string, string) io.ReadCloser {
+	p.diff++
+	b := new(bytes.Buffer)
+	x := ioutil.NopCloser(bytes.NewReader(b.Bytes()))
+	return x
+}
+
+func (p *testPlugin) Changes(string, string) ([]Change, error) {
+	p.changes++
+	return nil, nil
+}
+
+func (p *testPlugin) ApplyDiff(string, string, io.Reader) (int64, error) {
+	p.applyDiff++
+	return 42, nil
+}
+
+func (p *testPlugin) DiffSize(string, string) (int64, error) {
+	p.diffSize++
+	return 42, nil
+}

--- a/graphdriver/api_test.go
+++ b/graphdriver/api_test.go
@@ -47,6 +47,18 @@ func TestHandler(t *testing.T) {
 		t.Fatalf("expected create 1, got %d", p.create)
 	}
 
+	// CreateReadWrite
+	createReadWrite, err := CallCreateReadWrite(url, client, CreateRequest{ID: "foo", Parent: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if create.Err != "" {
+		t.Fatalf("got error creating read-write graph drivers: %v", createReadWrite.Err)
+	}
+	if p.createRW != 1 {
+		t.Fatalf("expected createReadWrite 1, got %d", p.createRW)
+	}
+
 	// Remove
 	remove, err := CallRemove(url, client, RemoveRequest{ID: "foo"})
 	if err != nil {
@@ -183,6 +195,7 @@ func TestHandler(t *testing.T) {
 type testPlugin struct {
 	init        int
 	create      int
+	createRW    int
 	remove      int
 	get         int
 	put         int
@@ -205,6 +218,11 @@ func (p *testPlugin) Init(string, []string) error {
 
 func (p *testPlugin) Create(string, string) error {
 	p.create++
+	return nil
+}
+
+func (p *testPlugin) CreateReadWrite(string, string) error {
+	p.createRW++
 	return nil
 }
 

--- a/graphdriver/api_test.go
+++ b/graphdriver/api_test.go
@@ -438,7 +438,7 @@ type testPlugin struct {
 
 var _ Driver = &testPlugin{}
 
-func (p *testPlugin) Init(string, map[string]string) error {
+func (p *testPlugin) Init(string, []string) error {
 	p.init++
 	return nil
 }

--- a/graphdriver/shim/shim.go
+++ b/graphdriver/shim/shim.go
@@ -32,7 +32,6 @@ func (d *shimDriver) Init(home string, options []string) error {
 	}
 	d.driver = driver
 	return nil
-
 }
 
 var errNotInitialized = errors.New("Not initialized")
@@ -44,6 +43,15 @@ func (d *shimDriver) Create(id, parent string) error {
 	// FIXME(samoht): no way to pass mountLayer to the plugin?
 	// FIXME(samoht): no way to pass storage options to the plugin?
 	return d.driver.Create(id, parent, "", nil)
+}
+
+func (d *shimDriver) CreateReadWrite(id, parent string) error {
+	if d == nil {
+		return errNotInitialized
+	}
+	// FIXME(samoht): no way to pass mountLayer to the plugin?
+	// FIXME(samoht): no way to pass storage options to the plugin?
+	return d.driver.CreateReadWrite(id, parent, "", nil)
 }
 
 func (d *shimDriver) Remove(id string) error {

--- a/graphdriver/shim/shim.go
+++ b/graphdriver/shim/shim.go
@@ -1,0 +1,153 @@
+package shim
+
+import (
+	"errors"
+	"io"
+	"log"
+
+	graphDriver "github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/archive"
+	graphPlugin "github.com/docker/go-plugins-helpers/graphdriver"
+)
+
+type shimDriver struct {
+	driver graphDriver.Driver
+	init   graphDriver.InitFunc
+}
+
+// NewHandlerFromGraphDriver creates a plugin handler from an existing graph
+// driver. This could be used, for instance, by the `overlayfs` graph driver
+// built-in to Docker Engine and it would create a plugin from it that maps
+// plugin API calls directly to any volume driver that satifies the
+// graphdriver.Driver interface from Docker Engine.
+func NewHandlerFromGraphDriver(init graphDriver.InitFunc) *graphPlugin.Handler {
+	return graphPlugin.NewHandler(&shimDriver{driver: nil, init: init})
+}
+
+func (d *shimDriver) Init(home string, options []string) error {
+	// FIXME(samoht): no way to pass UID and UID mapping?
+	driver, err := d.init(home, options, nil, nil)
+	if err != nil {
+		return err
+	}
+	d.driver = driver
+	return nil
+
+}
+
+var errNotInitialized = errors.New("Not initialized")
+
+func (d *shimDriver) Create(id, parent string) error {
+	if d == nil {
+		return errNotInitialized
+	}
+	// FIXME(samoht): no way to pass mountLayer to the plugin?
+	// FIXME(samoht): no way to pass storage options to the plugin?
+	return d.driver.Create(id, parent, "", nil)
+}
+
+func (d *shimDriver) Remove(id string) error {
+	if d == nil {
+		return errNotInitialized
+	}
+	return d.driver.Remove(id)
+}
+
+func (d *shimDriver) Get(id, mountLabel string) (string, error) {
+	if d == nil {
+		return "", errNotInitialized
+	}
+	return d.driver.Get(id, mountLabel)
+}
+
+func (d *shimDriver) Put(id string) error {
+	if d == nil {
+		return errNotInitialized
+	}
+	return d.driver.Put(id)
+}
+
+func (d *shimDriver) Exists(id string) bool {
+	if d == nil {
+		return false
+	}
+	return d.driver.Exists(id)
+}
+
+func (d *shimDriver) Status() [][2]string {
+	if d == nil {
+		return nil
+	}
+	return d.driver.Status()
+}
+
+func (d *shimDriver) GetMetadata(id string) (map[string]string, error) {
+	if d == nil {
+		return nil, errNotInitialized
+	}
+	return d.driver.GetMetadata(id)
+}
+
+func (d *shimDriver) Cleanup() error {
+	if d == nil {
+		return errNotInitialized
+	}
+	return d.driver.Cleanup()
+}
+
+func (d *shimDriver) Diff(id, parent string) io.ReadCloser {
+	if d == nil {
+		return nil
+	}
+	// FIXME(samoht): how do we pass the error to the driver?
+	archive, err := d.driver.Diff(id, parent)
+	if err != nil {
+		log.Fatalf("Diff: error in stream %v", err)
+	}
+	return archive
+}
+
+func changeKind(c archive.ChangeType) graphPlugin.ChangeKind {
+	switch c {
+	case archive.ChangeModify:
+		return graphPlugin.Modified
+	case archive.ChangeAdd:
+		return graphPlugin.Added
+	case archive.ChangeDelete:
+		return graphPlugin.Deleted
+	}
+	return 0
+}
+
+func (d *shimDriver) Changes(id, parent string) ([]graphPlugin.Change, error) {
+	if d == nil {
+		return nil, errNotInitialized
+	}
+	cs, err := d.driver.Changes(id, parent)
+	if err != nil {
+		return nil, err
+	}
+	changes := make([]graphPlugin.Change, len(cs))
+	for _, c := range cs {
+		change := graphPlugin.Change{
+			Path: c.Path,
+			Kind: changeKind(c.Kind),
+		}
+		changes = append(changes, change)
+	}
+	return changes, nil
+}
+
+func (d *shimDriver) ApplyDiff(id, parent string, archive io.Reader) (int64, error) {
+	if d == nil {
+		return 0, errNotInitialized
+	}
+	return d.driver.ApplyDiff(id, parent, archive)
+}
+
+func (d *shimDriver) DiffSize(id, parent string) (int64, error) {
+	if d == nil {
+		return 0, errNotInitialized
+	}
+	return d.driver.DiffSize(id, parent)
+}

--- a/graphdriver/shim/shim.go
+++ b/graphdriver/shim/shim.go
@@ -40,7 +40,6 @@ func (d *shimDriver) Create(id, parent string) error {
 	if d == nil {
 		return errNotInitialized
 	}
-	// FIXME(samoht): no way to pass mountLayer to the plugin?
 	// FIXME(samoht): no way to pass storage options to the plugin?
 	return d.driver.Create(id, parent, "", nil)
 }
@@ -49,7 +48,6 @@ func (d *shimDriver) CreateReadWrite(id, parent string) error {
 	if d == nil {
 		return errNotInitialized
 	}
-	// FIXME(samoht): no way to pass mountLayer to the plugin?
 	// FIXME(samoht): no way to pass storage options to the plugin?
 	return d.driver.CreateReadWrite(id, parent, "", nil)
 }

--- a/graphdriver/shim/shim_test.go
+++ b/graphdriver/shim/shim_test.go
@@ -1,0 +1,75 @@
+package shim
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/go-connections/sockets"
+	graphPlugin "github.com/docker/go-plugins-helpers/graphdriver"
+)
+
+type testGraphDriver struct{}
+
+// ProtoDriver
+var _ graphdriver.ProtoDriver = &testGraphDriver{}
+
+func (t *testGraphDriver) String() string {
+	return ""
+}
+
+// FIXME(samoht): this doesn't seem to be called by the plugins
+func (t *testGraphDriver) CreateReadWrite(id, parent, mountLabel string, storageOpt map[string]string) error {
+	return nil
+}
+func (t *testGraphDriver) Create(id, parent, mountLabel string, storageOpt map[string]string) error {
+	return nil
+}
+func (t *testGraphDriver) Remove(id string) error {
+	return nil
+}
+func (t *testGraphDriver) Get(id, mountLabel string) (dir string, err error) {
+	return "", nil
+}
+func (t *testGraphDriver) Put(id string) error {
+	return nil
+}
+func (t *testGraphDriver) Exists(id string) bool {
+	return false
+}
+func (t *testGraphDriver) Status() [][2]string {
+	return nil
+}
+func (t *testGraphDriver) GetMetadata(id string) (map[string]string, error) {
+	return nil, nil
+}
+func (t *testGraphDriver) Cleanup() error {
+	return nil
+}
+
+func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+	d := graphdriver.NewNaiveDiffDriver(&testGraphDriver{}, uidMaps, gidMaps)
+	return d, nil
+}
+
+const url = "http://localhost"
+
+func TestGraphDriver(t *testing.T) {
+	h := NewHandlerFromGraphDriver(Init)
+	l := sockets.NewInmemSocket("test", 0)
+	go h.Serve(l)
+	defer l.Close()
+
+	client := &http.Client{Transport: &http.Transport{
+		Dial: l.Dial,
+	}}
+
+	resp, err := graphPlugin.PluginInitRequest(url, client, graphPlugin.InitRequest{Home: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Err != "" {
+		t.Fatalf("error while creating GraphDriver: %v", err)
+	}
+}

--- a/graphdriver/shim/shim_test.go
+++ b/graphdriver/shim/shim_test.go
@@ -65,7 +65,7 @@ func TestGraphDriver(t *testing.T) {
 		Dial: l.Dial,
 	}}
 
-	resp, err := graphPlugin.PluginInitRequest(url, client, graphPlugin.InitRequest{Home: "foo"})
+	resp, err := graphPlugin.CallInit(url, client, graphPlugin.InitRequest{Home: "foo"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/encoder.go
+++ b/sdk/encoder.go
@@ -2,6 +2,9 @@ package sdk
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -23,4 +26,16 @@ func EncodeResponse(w http.ResponseWriter, res interface{}, err string) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	json.NewEncoder(w).Encode(res)
+}
+
+// StreamResponse streams a response object to the client
+func StreamResponse(w http.ResponseWriter, data io.ReadCloser) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	defer data.Close()
+	byteStream, err := ioutil.ReadAll(data)
+	if err != nil {
+		fmt.Printf("ERROR in stream: %v\n", err)
+		return
+	}
+	w.Write(byteStream)
 }


### PR DESCRIPTION
Thanks to @dave-tucker for the original version of this patch (see. #33). I've changed the interface slightly to simplify the creation of new plugins and I've added some tests, inspired from the volume helpers.

I have an other patch to add `shim.go` so we can use built-in graphdrivers as plugins, I need to write some test first (and figure how I can test that properly).