### PR TITLE
volume: shim: fix unit tests

### DIFF
--- a/volume/shim/shim.go
+++ b/volume/shim/shim.go
@@ -92,7 +92,7 @@ func (d *shimDriver) Mount(req volumeplugin.Request) volumeplugin.Response {
 		res.Err = err.Error()
 		return res
 	}
-	pth, err := v.Mount()
+	pth, err := v.Mount(req)
 	if err != nil {
 		res.Err = err.Error()
 	}
@@ -107,7 +107,7 @@ func (d *shimDriver) Unmount(req volumeplugin.Request) volumeplugin.Response {
 		res.Err = err.Error()
 		return res
 	}
-	if err := v.Unmount(); err != nil {
+	if err := v.Unmount(req); err != nil {
 		res.Err = err.Error()
 	}
 	return res


### PR DESCRIPTION
I'm not sure how those test failures went unnoticed (not sure the fix is to pass `req` to `Mount|Unmount`):
```
# github.com/docker/go-plugins-helpers/volume/shim
volume/shim/shim.go:95: not enough arguments in call to v.Mount
volume/shim/shim.go:110: not enough arguments in call to v.Unmount
```
found in https://github.com/docker/go-plugins-helpers/pull/48
ping @cpuguy83 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>