### PR TITLE
If hostname part of an address is empty, assume localhost.

### DIFF
--- a/sdk/tcp_listener.go
+++ b/sdk/tcp_listener.go
@@ -1,10 +1,12 @@
 package sdk
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/go-connections/sockets"
 )
@@ -14,6 +16,14 @@ const (
 )
 
 func newTCPListener(address string, pluginName string) (net.Listener, string, error) {
+	if address == "" {
+		return nil, "", fmt.Errorf("plugin address cannot be empty")
+	}
+	addrParts := strings.SplitN(address, ":", 2)
+	if addrParts[0] == "" {
+		address = "localhost" + address
+	}
+
 	listener, err := sockets.NewTCPSocket(address, nil)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
Binding plugins to a TCP port on localhost using ServeTCP("foo", ":12345")
does not work on Windows. This is because the golang net package does
not handle empty hostname/IP. https://github.com/golang/go/issues/6290
tracks it and is slated to be fixed in Go 1.8.

This change explicitly adds "localhost" if there's no hostname and
serve as a workaround until Golang fixes it.

Signed-off-by: Anusha Ragunathan anusha@docker.com
