### PR TITLE
authorization: decode using numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 REPO_NAME = go-plugins-helpers
 REPO_OWNER = docker
 PKG_NAME = github.com/${REPO_OWNER}/${REPO_NAME}
-IMAGE = golang:1.5
+IMAGE = golang:1.7
 
 all: test
 

--- a/authorization/api.go
+++ b/authorization/api.go
@@ -1,6 +1,7 @@
 package authorization
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/docker/docker/pkg/authorization"
@@ -52,9 +53,13 @@ type actionHandler func(Request) Response
 
 func (h *Handler) handle(name string, actionCall actionHandler) {
 	h.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
-		var req Request
-		if err := sdk.DecodeRequest(w, r, &req); err != nil {
-			return
+		var (
+			req Request
+			d   = json.NewDecoder(r.Body)
+		)
+		d.UseNumber()
+		if err := d.Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 
 		res := actionCall(req)


### PR DESCRIPTION
We can't use structs with big integers in authorization Request otherwise :smile_cat: 

@vdemeester PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>