### PR TITLE
Implement a windows listener using named pipes.

### DIFF
--- a/authorization/api_test.go
+++ b/authorization/api_test.go
@@ -132,7 +132,7 @@ func TestAuthZRes(t *testing.T) {
 func TestMain(m *testing.M) {
 	d := &TestPlugin{}
 	h := NewHandler(d)
-	go h.ServeTCP("test", ":32456", nil)
+	go h.ServeTCP("test", ":32456", "", nil)
 
 	os.Exit(m.Run())
 }

--- a/network/README.md
+++ b/network/README.md
@@ -8,7 +8,7 @@ This library is designed to be integrated in your program.
 
 1. Implement the `network.Driver` interface.
 2. Initialize a `network.Handler` with your implementation.
-3. Call either `ServeTCP` or `ServeUnix` from the `network.Handler`.
+3. Call either `ServeTCP`, `ServeUnix` or `ServeWindows` from the `network.Handler`.
 
 ### Example using TCP sockets:
 
@@ -28,6 +28,26 @@ This library is designed to be integrated in your program.
   d := MyNetworkDriver{}
   h := network.NewHandler(d)
   h.ServeUnix("root", "test_network")
+```
+
+### Example using Windows named pipes:
+
+```go
+import "github.com/docker/go-plugins-helpers/network"
+import "github.com/docker/go-plugins-helpers/sdk"
+
+d := MyNetworkDriver{}
+h := network.NewHandler(d)
+
+config := sdk.WindowsPipeConfig{
+  // open, read, write permissions for everyone 
+  // (uses Windows Security Descriptor Definition Language)
+  SecurityDescriptor: "S:(ML;;NW;;;LW)D:(A;;0x12019f;;;WD)",
+  InBufferSize:       4096,
+  OutBufferSize:      4096,
+}
+
+h.ServeWindows("//./pipe/testpipe", "test_network", &config)
 ```
 
 ## Full example plugins

--- a/network/README.md
+++ b/network/README.md
@@ -9,6 +9,8 @@ This library is designed to be integrated in your program.
 1. Implement the `network.Driver` interface.
 2. Initialize a `network.Handler` with your implementation.
 3. Call either `ServeTCP`, `ServeUnix` or `ServeWindows` from the `network.Handler`.
+4. On Windows, docker daemon data dir must be provided for ServeTCP and ServeWindows functions.
+However, providing an empty string will use the default value.
 
 ### Example using TCP sockets:
 
@@ -17,7 +19,7 @@ This library is designed to be integrated in your program.
 
   d := MyNetworkDriver{}
   h := network.NewHandler(d)
-  h.ServeTCP("test_network", ":8080")
+  h.ServeTCP("test_network", ":8080", "")
 ```
 
 ### Example using Unix sockets:
@@ -47,7 +49,7 @@ config := sdk.WindowsPipeConfig{
   OutBufferSize:      4096,
 }
 
-h.ServeWindows("//./pipe/testpipe", "test_network", &config)
+h.ServeWindows("//./pipe/testpipe", "test_network", "", &config)
 ```
 
 ## Full example plugins

--- a/network/README.md
+++ b/network/README.md
@@ -10,7 +10,7 @@ This library is designed to be integrated in your program.
 2. Initialize a `network.Handler` with your implementation.
 3. Call either `ServeTCP`, `ServeUnix` or `ServeWindows` from the `network.Handler`.
 4. On Windows, docker daemon data dir must be provided for ServeTCP and ServeWindows functions.
-However, providing an empty string will use the default value.
+On Unix, this parameter is ignored.
 
 ### Example using TCP sockets:
 
@@ -20,6 +20,8 @@ However, providing an empty string will use the default value.
   d := MyNetworkDriver{}
   h := network.NewHandler(d)
   h.ServeTCP("test_network", ":8080", "")
+  // on windows:
+  h.ServeTCP("test_network", ":8080", WindowsDefaultDaemonRootDir())
 ```
 
 ### Example using Unix sockets:
@@ -49,7 +51,7 @@ config := sdk.WindowsPipeConfig{
   OutBufferSize:      4096,
 }
 
-h.ServeWindows("//./pipe/testpipe", "test_network", "", &config)
+h.ServeWindows("//./pipe/testpipe", "test_network", WindowsDefaultDaemonRootDir(), &config)
 ```
 
 ## Full example plugins

--- a/network/README.md
+++ b/network/README.md
@@ -42,7 +42,7 @@ h := network.NewHandler(d)
 config := sdk.WindowsPipeConfig{
   // open, read, write permissions for everyone 
   // (uses Windows Security Descriptor Definition Language)
-  SecurityDescriptor: "S:(ML;;NW;;;LW)D:(A;;0x12019f;;;WD)",
+  SecurityDescriptor: AllowServiceSystemAdmin,
   InBufferSize:       4096,
   OutBufferSize:      4096,
 }

--- a/network/api_test.go
+++ b/network/api_test.go
@@ -98,11 +98,11 @@ func (e *ErrDriver) Leave(r *LeaveRequest) error {
 func TestMain(m *testing.M) {
 	d := &TestDriver{}
 	h1 := NewHandler(d)
-	go h1.ServeTCP("test", ":32234", nil)
+	go h1.ServeTCP("test", ":32234", "", nil)
 
 	e := &ErrDriver{}
 	h2 := NewHandler(e)
-	go h2.ServeTCP("err", ":32567", nil)
+	go h2.ServeTCP("err", ":32567", "", nil)
 
 	m.Run()
 }

--- a/sdk/handler.go
+++ b/sdk/handler.go
@@ -39,8 +39,11 @@ func (h Handler) Serve(l net.Listener) error {
 
 // ServeTCP makes the handler to listen for request in a given TCP address.
 // It also writes the spec file in the right directory for docker to read.
-func (h Handler) ServeTCP(pluginName, addr string, tlsConfig *tls.Config) error {
-	l, spec, err := newTCPListener(addr, pluginName, tlsConfig)
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. Providing an empty string ("") will be interpreted
+// as using the default directory. On Unix, this parameter is ignored.
+func (h Handler) ServeTCP(pluginName, addr, daemonDir string, tlsConfig *tls.Config) error {
+	l, spec, err := newTCPListener(addr, pluginName, daemonDir, tlsConfig)
 	if err != nil {
 		return err
 	}
@@ -63,10 +66,13 @@ func (h Handler) ServeUnix(addr string, gid int) error {
 	return h.Serve(l)
 }
 
-// ServeWindows makes the handler to listen for request in a windows named pipe.
+// ServeWindows makes the handler to listen for request in a Windows named pipe.
 // It also creates the spec file in the right directory for docker to read.
-func (h Handler) ServeWindows(addr, pluginName string, pipeConfig *WindowsPipeConfig) error {
-	l, spec, err := newWindowsListener(addr, pluginName, pipeConfig)
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. Providing an empty string ("") will be interpreted
+// as using the default directory.
+func (h Handler) ServeWindows(addr, pluginName, daemonDir string, pipeConfig *WindowsPipeConfig) error {
+	l, spec, err := newWindowsListener(addr, pluginName, daemonDir, pipeConfig)
 	if err != nil {
 		return err
 	}

--- a/sdk/handler.go
+++ b/sdk/handler.go
@@ -38,7 +38,7 @@ func (h Handler) Serve(l net.Listener) error {
 }
 
 // ServeTCP makes the handler to listen for request in a given TCP address.
-// It also writes the spec file on the right directory for docker to read.
+// It also writes the spec file in the right directory for docker to read.
 func (h Handler) ServeTCP(pluginName, addr string, tlsConfig *tls.Config) error {
 	l, spec, err := newTCPListener(addr, pluginName, tlsConfig)
 	if err != nil {
@@ -51,9 +51,22 @@ func (h Handler) ServeTCP(pluginName, addr string, tlsConfig *tls.Config) error 
 }
 
 // ServeUnix makes the handler to listen for requests in a unix socket.
-// It also creates the socket file on the right directory for docker to read.
+// It also creates the socket file in the right directory for docker to read.
 func (h Handler) ServeUnix(addr string, gid int) error {
 	l, spec, err := newUnixListener(addr, gid)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// ServeWindows makes the handler to listen for request in a windows named pipe.
+// It also creates the spec file in the right directory for docker to read.
+func (h Handler) ServeWindows(addr, pluginName string, pipeConfig *WindowsPipeConfig) error {
+	l, spec, err := newWindowsListener(addr, pluginName, pipeConfig)
 	if err != nil {
 		return err
 	}

--- a/sdk/handler.go
+++ b/sdk/handler.go
@@ -40,8 +40,8 @@ func (h Handler) Serve(l net.Listener) error {
 // ServeTCP makes the handler to listen for request in a given TCP address.
 // It also writes the spec file in the right directory for docker to read.
 // Due to constrains for running Docker in Docker on Windows, data-root directory
-// of docker daemon must be provided. Providing an empty string ("") will be interpreted
-// as using the default directory. On Unix, this parameter is ignored.
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
 func (h Handler) ServeTCP(pluginName, addr, daemonDir string, tlsConfig *tls.Config) error {
 	l, spec, err := newTCPListener(addr, pluginName, daemonDir, tlsConfig)
 	if err != nil {
@@ -69,8 +69,8 @@ func (h Handler) ServeUnix(addr string, gid int) error {
 // ServeWindows makes the handler to listen for request in a Windows named pipe.
 // It also creates the spec file in the right directory for docker to read.
 // Due to constrains for running Docker in Docker on Windows, data-root directory
-// of docker daemon must be provided. Providing an empty string ("") will be interpreted
-// as using the default directory.
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
 func (h Handler) ServeWindows(addr, pluginName, daemonDir string, pipeConfig *WindowsPipeConfig) error {
 	l, spec, err := newWindowsListener(addr, pluginName, daemonDir, pipeConfig)
 	if err != nil {

--- a/sdk/spec_file_generator.go
+++ b/sdk/spec_file_generator.go
@@ -1,0 +1,37 @@
+package sdk
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type protocol string
+
+const (
+	protoTCP       protocol = "tcp"
+	protoNamedPipe protocol = "npipe"
+)
+
+func writeSpec(name, address string, proto protocol) (string, error) {
+
+	var pluginSpecDir string
+	if runtime.GOOS == "windows" {
+		pluginSpecDir = ([]string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")})[0]
+	} else {
+		pluginSpecDir = "/etc/docker/plugins"
+	}
+
+	if err := os.MkdirAll(pluginSpecDir, 0755); err != nil {
+		return "", err
+	}
+	spec := filepath.Join(pluginSpecDir, name+".spec")
+
+	url := string(proto) + "://" + address
+	if err := ioutil.WriteFile(spec, []byte(url), 0644); err != nil {
+		return "", err
+	}
+
+	return spec, nil
+}

--- a/sdk/spec_file_generator.go
+++ b/sdk/spec_file_generator.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,11 +19,19 @@ func PluginSpecDir(daemonRoot string) string {
 	return ([]string{filepath.Join(daemonRoot, "plugins")})[0]
 }
 
+// WindowsDefaultDaemonRootDir returns default data directory of docker daemon on Windows.
+func WindowsDefaultDaemonRootDir() string {
+	return filepath.Join(os.Getenv("programdata"), "docker")
+}
+
 func createPluginSpecDirWindows(name, address, daemonRoot string) (string, error) {
-	if daemonRoot == "" {
-		daemonRoot = filepath.Join(os.Getenv("programdata"), "docker")
+	_, err := os.Stat(daemonRoot)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("Deamon root directory must already exist: %s", err)
 	}
+
 	pluginSpecDir := PluginSpecDir(daemonRoot)
+
 	if err := windowsCreateDirectoryWithACL(pluginSpecDir); err != nil {
 		return "", err
 	}

--- a/sdk/spec_file_generator.go
+++ b/sdk/spec_file_generator.go
@@ -19,13 +19,16 @@ func writeSpec(name, address string, proto protocol) (string, error) {
 	var pluginSpecDir string
 	if runtime.GOOS == "windows" {
 		pluginSpecDir = ([]string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")})[0]
+		if err := windowsCreateDirectory(pluginSpecDir); err != nil {
+			return "", err
+		}
 	} else {
 		pluginSpecDir = "/etc/docker/plugins"
+		if err := os.MkdirAll(pluginSpecDir, 0755); err != nil {
+			return "", err
+		}
 	}
 
-	if err := os.MkdirAll(pluginSpecDir, 0755); err != nil {
-		return "", err
-	}
 	spec := filepath.Join(pluginSpecDir, name+".spec")
 
 	url := string(proto) + "://" + address

--- a/sdk/tcp_listener.go
+++ b/sdk/tcp_listener.go
@@ -7,16 +7,14 @@ import (
 	"github.com/docker/go-connections/sockets"
 )
 
-func newTCPListener(address string, pluginName string, tlsConfig *tls.Config) func() (net.Listener, string, string, error) {
-	return func() (net.Listener, string, string, error) {
-		listener, err := sockets.NewTCPSocket(address, tlsConfig)
-		if err != nil {
-			return nil, "", "", err
-		}
-		spec, err := writeSpec(pluginName, listener.Addr().String(), protoTCP)
-		if err != nil {
-			return nil, "", "", err
-		}
-		return listener, address, spec, nil
+func newTCPListener(address string, pluginName string, tlsConfig *tls.Config) (net.Listener, string, error) {
+	listener, err := sockets.NewTCPSocket(address, tlsConfig)
+	if err != nil {
+		return nil, "", err
 	}
+	spec, err := writeSpec(pluginName, listener.Addr().String(), protoTCP)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, spec, nil
 }

--- a/sdk/tcp_listener.go
+++ b/sdk/tcp_listener.go
@@ -3,18 +3,32 @@ package sdk
 import (
 	"crypto/tls"
 	"net"
+	"runtime"
 
 	"github.com/docker/go-connections/sockets"
 )
 
-func newTCPListener(address string, pluginName string, tlsConfig *tls.Config) (net.Listener, string, error) {
+func newTCPListener(address, pluginName, daemonDir string, tlsConfig *tls.Config) (net.Listener, string, error) {
 	listener, err := sockets.NewTCPSocket(address, tlsConfig)
 	if err != nil {
 		return nil, "", err
 	}
-	spec, err := writeSpec(pluginName, listener.Addr().String(), protoTCP)
+
+	addr := listener.Addr().String()
+
+	var specDir string
+	if runtime.GOOS == "windows" {
+		specDir, err = createPluginSpecDirWindows(pluginName, addr, daemonDir)
+	} else {
+		specDir, err = createPluginSpecDirUnix(pluginName, addr)
+	}
 	if err != nil {
 		return nil, "", err
 	}
-	return listener, spec, nil
+
+	specFile, err := writeSpecFile(pluginName, addr, specDir, protoTCP)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, specFile, nil
 }

--- a/sdk/unix_listener_unsupported.go
+++ b/sdk/unix_listener_unsupported.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on linux and freebsd")
+	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on Linux and FreeBSD")
 )
 
 func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {

--- a/sdk/windows_listener.go
+++ b/sdk/windows_listener.go
@@ -4,24 +4,59 @@ package sdk
 
 import (
 	"net"
+	"os"
+	"syscall"
+	"unsafe"
 
 	"github.com/Microsoft/go-winio"
+)
+
+// Named pipes use Windows Security Descriptor Definition Language to define ACL. Following are
+// some useful definitions.
+const (
+	// This will set permissions for everyone to have full access
+	AllowEveryone = "S:(ML;;NW;;;LW)D:(A;;0x12019f;;;WD)"
+
+	// This will set permissions for Service, System, Adminstrator group and account to have full access
+	AllowServiceSystemAdmin = "D:(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;FA;;;LA)(A;ID;FA;;;LS)"
 )
 
 func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
 	winioPipeConfig := winio.PipeConfig{
 		SecurityDescriptor: pipeConfig.SecurityDescriptor,
-		MessageMode:        true,
 		InputBufferSize:    pipeConfig.InBufferSize,
 		OutputBufferSize:   pipeConfig.OutBufferSize,
 	}
 	listener, err := winio.ListenPipe(address, &winioPipeConfig)
 	if err != nil {
-		return nil, "", "", err
+		return nil, "", err
 	}
 	spec, err := writeSpec(pluginName, listener.Addr().String(), protoNamedPipe)
 	if err != nil {
-		return nil, "", "", err
+		return nil, "", err
 	}
 	return listener, spec, nil
+}
+
+func windowsCreateDirectory(name string) error {
+	sa := syscall.SecurityAttributes{Length: 0}
+	sddl := "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
+	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+
+	e := syscall.CreateDirectory(namep, &sa)
+	if e != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: e}
+	}
+	return nil
 }

--- a/sdk/windows_listener.go
+++ b/sdk/windows_listener.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package sdk
+
+import (
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	winioPipeConfig := winio.PipeConfig{
+		SecurityDescriptor: pipeConfig.SecurityDescriptor,
+		MessageMode:        true,
+		InputBufferSize:    pipeConfig.InBufferSize,
+		OutputBufferSize:   pipeConfig.OutBufferSize,
+	}
+	listener, err := winio.ListenPipe(address, &winioPipeConfig)
+	if err != nil {
+		return nil, "", "", err
+	}
+	spec, err := writeSpec(pluginName, listener.Addr().String(), protoNamedPipe)
+	if err != nil {
+		return nil, "", "", err
+	}
+	return listener, spec, nil
+}

--- a/sdk/windows_listener_unsupported.go
+++ b/sdk/windows_listener_unsupported.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnWindows = errors.New("named pipe creation is only supported on Windows")
+)
+
+func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) func() (net.Listener, string, string, error) {
+	return func() (net.Listener, string, string, error) {
+		return nil, "", "", errOnlySupportedOnWindows
+	}
+}

--- a/sdk/windows_listener_unsupported.go
+++ b/sdk/windows_listener_unsupported.go
@@ -11,8 +11,10 @@ var (
 	errOnlySupportedOnWindows = errors.New("named pipe creation is only supported on Windows")
 )
 
-func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) func() (net.Listener, string, string, error) {
-	return func() (net.Listener, string, string, error) {
-		return nil, "", "", errOnlySupportedOnWindows
-	}
+func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	return nil, "", errOnlySupportedOnWindows
+}
+
+func windowsCreateDirectory(name string) error {
+	return nil
 }

--- a/sdk/windows_listener_unsupported.go
+++ b/sdk/windows_listener_unsupported.go
@@ -11,10 +11,10 @@ var (
 	errOnlySupportedOnWindows = errors.New("named pipe creation is only supported on Windows")
 )
 
-func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+func newWindowsListener(address, pluginName, daemonRoot string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
 	return nil, "", errOnlySupportedOnWindows
 }
 
-func windowsCreateDirectory(name string) error {
+func windowsCreateDirectoryWithACL(name string) error {
 	return nil
 }

--- a/sdk/windows_pipe_config.go
+++ b/sdk/windows_pipe_config.go
@@ -1,0 +1,13 @@
+package sdk
+
+// WindowsPipeConfig is a helper structure for configuring named pipe parameters on Windows.
+type WindowsPipeConfig struct {
+	// SecurityDescriptor contains a Windows security descriptor in SDDL format.
+	SecurityDescriptor string
+
+	// InBufferSize in bytes.
+	InBufferSize int32
+
+	// OutBufferSize in bytes.
+	OutBufferSize int32
+}


### PR DESCRIPTION
This lets us implement remote drivers on Windows that use named pipes for docker daemon - driver communication.

Signed-off-by: Michal Kostrzewa <kostrzewa.michal@o2.pl>