### PR TITLE
Remove use of cgo

### DIFF
--- a/sdk/handler.go
+++ b/sdk/handler.go
@@ -40,45 +40,30 @@ func (h Handler) Serve(l net.Listener) error {
 // ServeTCP makes the handler to listen for request in a given TCP address.
 // It also writes the spec file on the right directory for docker to read.
 func (h Handler) ServeTCP(pluginName, addr string, tlsConfig *tls.Config) error {
-	return h.listenAndServe("tcp", addr, pluginName, tlsConfig)
+	l, spec, err := newTCPListener(addr, pluginName, tlsConfig)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
 }
 
 // ServeUnix makes the handler to listen for requests in a unix socket.
 // It also creates the socket file on the right directory for docker to read.
-func (h Handler) ServeUnix(systemGroup, addr string) error {
-	return h.listenAndServe("unix", addr, systemGroup, nil)
+func (h Handler) ServeUnix(addr string, gid int) error {
+	l, spec, err := newUnixListener(addr, gid)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
 }
 
 // HandleFunc registers a function to handle a request path with.
 func (h Handler) HandleFunc(path string, fn func(w http.ResponseWriter, r *http.Request)) {
 	h.mux.HandleFunc(path, fn)
-}
-
-func (h Handler) listenAndServe(proto, addr, group string, tlsConfig *tls.Config) error {
-	var (
-		err  error
-		spec string
-		l    net.Listener
-	)
-
-	server := http.Server{
-		Addr:    addr,
-		Handler: h.mux,
-	}
-
-	switch proto {
-	case "tcp":
-		l, spec, err = newTCPListener(addr, group, tlsConfig)
-	case "unix":
-		l, spec, err = newUnixListener(addr, group)
-	}
-
-	if spec != "" {
-		defer os.Remove(spec)
-	}
-	if err != nil {
-		return err
-	}
-
-	return server.Serve(l)
 }

--- a/sdk/unix_listener.go
+++ b/sdk/unix_listener.go
@@ -3,13 +3,10 @@
 package sdk
 
 import (
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 
-	"github.com/coreos/go-systemd/activation"
-	"github.com/coreos/go-systemd/util"
 	"github.com/docker/go-connections/sockets"
 )
 
@@ -17,20 +14,14 @@ const (
 	pluginSockDir = "/run/docker/plugins"
 )
 
-func newUnixListener(pluginName string, group string) (net.Listener, string, error) {
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
 	path, err := fullSocketAddress(pluginName)
 	if err != nil {
 		return nil, "", err
 	}
-	listener, err := setupSocketActivation()
+	listener, err := sockets.NewUnixSocket(path, gid)
 	if err != nil {
 		return nil, "", err
-	}
-	if listener == nil {
-		listener, err = sockets.NewUnixSocket(path, group)
-		if err != nil {
-			return nil, "", err
-		}
 	}
 	return listener, path, nil
 }
@@ -43,23 +34,4 @@ func fullSocketAddress(address string) (string, error) {
 		return address, nil
 	}
 	return filepath.Join(pluginSockDir, address+".sock"), nil
-}
-
-func setupSocketActivation() (net.Listener, error) {
-	if !util.IsRunningSystemd() {
-		return nil, nil
-	}
-	listenFds := activation.Files(false)
-	if len(listenFds) > 1 {
-		return nil, fmt.Errorf("expected only one socket from systemd, got %d", len(listenFds))
-	}
-	var listener net.Listener
-	if len(listenFds) == 1 {
-		l, err := net.FileListener(listenFds[0])
-		if err != nil {
-			return nil, err
-		}
-		listener = l
-	}
-	return listener, nil
 }

--- a/sdk/unix_listener_unsupported.go
+++ b/sdk/unix_listener_unsupported.go
@@ -11,6 +11,6 @@ var (
 	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on linux and freebsd")
 )
 
-func newUnixListener(pluginName string, group string) (net.Listener, string, error) {
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
 	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
 }


### PR DESCRIPTION
This makes it possible to cross-compile plugins.
Builds on top of docker/go-connections#26

If a plugin author wants to do group lookup, they can do it in their own
way and pass in the gid.
As is, this is too much for a library and makes it incredibly annoying
to use.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>