### PR TITLE
Fix Docker authorization extension full-example link

### DIFF
--- a/authorization/README.md
+++ b/authorization/README.md
@@ -28,7 +28,7 @@ This library is designed to be integrated in your program.
 
 ## Full example plugins
 
-- https://github.com/runcom/docker-novolume-plugin
+- https://github.com/projectatomic/docker-novolume-plugin
 
 ## License
 


### PR DESCRIPTION
 Modifed docker-novolume-plugin link to moved repository 
 [runcom/docker-novolume-plugin](https://github.com/runcom/docker-novolume-plugin) moved to [projectatomic/docker-novolume-plugin](https://github.com/projectatomic/docker-novolume-plugin)
