### PR TITLE
Refactor Volume

### DIFF
--- a/volume/README.md
+++ b/volume/README.md
@@ -23,10 +23,13 @@ This library is designed to be integrated in your program.
 ```go
   d := MyVolumeDriver{}
   h := volume.NewHandler(d)
-  h.ServeUnix("root", "test_volume")
+  u, _ := user.Lookup("root")
+  gid, _ := strconv.Atoi(u.Gid)
+  h.ServeUnix("test_volume", gid)
 ```
 
 ## Full example plugins
 
 - https://github.com/calavera/docker-volume-glusterfs
 - https://github.com/calavera/docker-volume-keywhiz
+- https://github.com/quobyte/docker-volume

--- a/volume/api.go
+++ b/volume/api.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/docker/go-plugins-helpers/sdk"
@@ -21,10 +22,15 @@ const (
 	capabilitiesPath = "/VolumeDriver.Capabilities"
 )
 
-// Request is the structure that docker's requests are deserialized to.
-type Request struct {
+// CreateRequest is the structure that docker's requests are deserialized to.
+type CreateRequest struct {
 	Name    string
 	Options map[string]string `json:"Opts,omitempty"`
+}
+
+// RemoveRequest structure for a volume remove request
+type RemoveRequest struct {
+	Name string
 }
 
 // MountRequest structure for a volume mount request
@@ -33,18 +39,49 @@ type MountRequest struct {
 	ID   string
 }
 
+// MountResponse structure for a volume mount response
+type MountResponse struct {
+	Mountpoint string
+	Err        string
+}
+
 // UnmountRequest structure for a volume unmount request
 type UnmountRequest struct {
 	Name string
 	ID   string
 }
 
-// Response is the strucutre that the plugin's responses are serialized to.
-type Response struct {
-	Mountpoint   string
+// PathRequest structure for a volume path request
+type PathRequest struct {
+	Name string
+}
+
+// PathResponse structure for a volume path response
+type PathResponse struct {
+	Mountpoint string
+	Err        string
+}
+
+// GetRequest structure for a volume get request
+type GetRequest struct {
+	Name string
+}
+
+// GetResponse structure for a volume get response
+type GetResponse struct {
+	Err    string
+	Volume *Volume
+}
+
+// ListResponse structure for a volume list response
+type ListResponse struct {
+	Err     string
+	Volumes []*Volume
+}
+
+// CapabilitiesResponse structure for a volume capability response
+type CapabilitiesResponse struct {
 	Err          string
-	Volumes      []*Volume
-	Volume       *Volume
 	Capabilities Capability
 }
 
@@ -60,16 +97,26 @@ type Capability struct {
 	Scope string
 }
 
+// ErrorResponse is a formatted error message that docker can understand
+type ErrorResponse struct {
+	Err string
+}
+
+// NewErrorResponse creates an ErrorResponse with the provided message
+func NewErrorResponse(msg string) *ErrorResponse {
+	return &ErrorResponse{Err: msg}
+}
+
 // Driver represent the interface a driver must fulfill.
 type Driver interface {
-	Create(Request) Response
-	List(Request) Response
-	Get(Request) Response
-	Remove(Request) Response
-	Path(Request) Response
-	Mount(MountRequest) Response
-	Unmount(UnmountRequest) Response
-	Capabilities(Request) Response
+	Create(*CreateRequest) error
+	List() (*ListResponse, error)
+	Get(*GetRequest) (*GetResponse, error)
+	Remove(*RemoveRequest) error
+	Path(*PathRequest) (*PathResponse, error)
+	Mount(*MountRequest) (*MountResponse, error)
+	Unmount(*UnmountRequest) error
+	Capabilities() *CapabilitiesResponse
 }
 
 // Handler forwards requests and responses between the docker daemon and the plugin.
@@ -77,10 +124,6 @@ type Handler struct {
 	driver Driver
 	sdk.Handler
 }
-
-type actionHandler func(Request) Response
-type mountActionHandler func(MountRequest) Response
-type unmountActionHandler func(UnmountRequest) Response
 
 // NewHandler initializes the request handler with a driver implementation.
 func NewHandler(driver Driver) *Handler {
@@ -90,71 +133,101 @@ func NewHandler(driver Driver) *Handler {
 }
 
 func (h *Handler) initMux() {
-	h.handle(createPath, func(req Request) Response {
-		return h.driver.Create(req)
-	})
-
-	h.handle(getPath, func(req Request) Response {
-		return h.driver.Get(req)
-	})
-
-	h.handle(listPath, func(req Request) Response {
-		return h.driver.List(req)
-	})
-
-	h.handle(removePath, func(req Request) Response {
-		return h.driver.Remove(req)
-	})
-
-	h.handle(hostVirtualPath, func(req Request) Response {
-		return h.driver.Path(req)
-	})
-
-	h.handleMount(mountPath, func(req MountRequest) Response {
-		return h.driver.Mount(req)
-	})
-
-	h.handleUnmount(unmountPath, func(req UnmountRequest) Response {
-		return h.driver.Unmount(req)
-	})
-	h.handle(capabilitiesPath, func(req Request) Response {
-		return h.driver.Capabilities(req)
-	})
-}
-
-func (h *Handler) handle(name string, actionCall actionHandler) {
-	h.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
-		var req Request
-		if err := sdk.DecodeRequest(w, r, &req); err != nil {
+	h.HandleFunc(createPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers createPath")
+		req := &CreateRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
 			return
 		}
-
-		res := actionCall(req)
-
-		sdk.EncodeResponse(w, res, res.Err)
-	})
-}
-
-func (h *Handler) handleMount(name string, actionCall mountActionHandler) {
-	h.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
-		var req MountRequest
-		if err := sdk.DecodeRequest(w, r, &req); err != nil {
+		err = h.driver.Create(req)
+		if err != nil {
+			msg := err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
 			return
 		}
-
-		res := actionCall(req)
-		sdk.EncodeResponse(w, res, res.Err)
+		sdk.EncodeResponse(w, NewErrorResponse(""), "")
 	})
-}
-
-func (h *Handler) handleUnmount(name string, actionCall unmountActionHandler) {
-	h.HandleFunc(name, func(w http.ResponseWriter, r *http.Request) {
-		var req UnmountRequest
-		if err := sdk.DecodeRequest(w, r, &req); err != nil {
+	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers removePath")
+		req := &RemoveRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
 			return
 		}
+		err = h.driver.Remove(req)
+		if err != nil {
+			msg := err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			return
+		}
+		sdk.EncodeResponse(w, NewErrorResponse(""), "")
+	})
+	h.HandleFunc(mountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers mountPath")
+		req := &MountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Mount(req)
+		if err != nil {
+			res.Err = err.Error()
+		}
+		sdk.EncodeResponse(w, res, "")
+	})
+	h.HandleFunc(hostVirtualPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers hostVirtualPath")
+		req := &PathRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Path(req)
+		if err != nil {
+			res.Err = err.Error()
+		}
+		sdk.EncodeResponse(w, res, "")
+	})
+	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers getPath")
+		req := &GetRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Get(req)
+		if err != nil {
+			res.Err = err.Error()
+		}
+		sdk.EncodeResponse(w, res, "")
+	})
+	h.HandleFunc(unmountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers unmountPath")
+		req := &UnmountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Unmount(req)
+		if err != nil {
+			msg := err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			return
+		}
+		sdk.EncodeResponse(w, NewErrorResponse(""), "")
+	})
+	h.HandleFunc(listPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers listPath")
+		res, err := h.driver.List()
+		if err != nil {
+			res.Err = err.Error()
+		}
+		sdk.EncodeResponse(w, res, "")
+	})
 
-		res := actionCall(req)
-		sdk.EncodeResponse(w, res, res.Err)
+	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers capabilitiesPath")
+		sdk.EncodeResponse(w, h.driver.Capabilities(), "")
 	})
 }

--- a/volume/shim/shim.go
+++ b/volume/shim/shim.go
@@ -18,21 +18,17 @@ func NewHandlerFromVolumeDriver(d volume.Driver) *volumeplugin.Handler {
 	return volumeplugin.NewHandler(&shimDriver{d})
 }
 
-func (d *shimDriver) Create(req volumeplugin.Request) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) Create(req *volumeplugin.CreateRequest) error {
 	_, err := d.d.Create(req.Name, req.Options)
-	if err != nil {
-		res.Err = err.Error()
-	}
-	return res
+	return err
 }
 
-func (d *shimDriver) List(req volumeplugin.Request) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) List() (*volumeplugin.ListResponse, error) {
+	var res *volumeplugin.ListResponse
 	ls, err := d.d.List()
 	if err != nil {
 		res.Err = err.Error()
-		return res
+		return &volumeplugin.ListResponse{}, err
 	}
 	vols := make([]*volumeplugin.Volume, len(ls))
 
@@ -44,78 +40,74 @@ func (d *shimDriver) List(req volumeplugin.Request) volumeplugin.Response {
 		vols[i] = vol
 	}
 	res.Volumes = vols
-	return res
+	return res, nil
 }
 
-func (d *shimDriver) Get(req volumeplugin.Request) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) Get(req *volumeplugin.GetRequest) (*volumeplugin.GetResponse, error) {
+	var res *volumeplugin.GetResponse
 	v, err := d.d.Get(req.Name)
 	if err != nil {
 		res.Err = err.Error()
-		return res
+		return &volumeplugin.GetResponse{}, err
 	}
 	res.Volume = &volumeplugin.Volume{
 		Name:       v.Name(),
 		Mountpoint: v.Path(),
 		Status:     v.Status(),
 	}
-	return res
+	return &volumeplugin.GetResponse{}, nil
 }
 
-func (d *shimDriver) Remove(req volumeplugin.Request) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) Remove(req *volumeplugin.RemoveRequest) error {
 	v, err := d.d.Get(req.Name)
 	if err != nil {
-		res.Err = err.Error()
-		return res
+		return err
 	}
 	if err := d.d.Remove(v); err != nil {
-		res.Err = err.Error()
+		return err
 	}
-	return res
+	return nil
 }
 
-func (d *shimDriver) Path(req volumeplugin.Request) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) Path(req *volumeplugin.PathRequest) (*volumeplugin.PathResponse, error) {
+	var res *volumeplugin.PathResponse
 	v, err := d.d.Get(req.Name)
 	if err != nil {
 		res.Err = err.Error()
-		return res
+		return res, err
 	}
 	res.Mountpoint = v.Path()
-	return res
+	return res, nil
 }
 
-func (d *shimDriver) Mount(req volumeplugin.MountRequest) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) Mount(req *volumeplugin.MountRequest) (*volumeplugin.MountResponse, error) {
+	var res *volumeplugin.MountResponse
 	v, err := d.d.Get(req.Name)
 	if err != nil {
 		res.Err = err.Error()
-		return res
+		return res, err
 	}
 	pth, err := v.Mount(req.ID)
 	if err != nil {
 		res.Err = err.Error()
 	}
 	res.Mountpoint = pth
-	return res
+	return res, nil
 }
 
-func (d *shimDriver) Unmount(req volumeplugin.UnmountRequest) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) Unmount(req *volumeplugin.UnmountRequest) error {
 	v, err := d.d.Get(req.Name)
 	if err != nil {
-		res.Err = err.Error()
-		return res
+		return err
 	}
 	if err := v.Unmount(req.ID); err != nil {
-		res.Err = err.Error()
+		return err
 	}
-	return res
+	return nil
 }
 
-func (d *shimDriver) Capabilities(req volumeplugin.Request) volumeplugin.Response {
-	var res volumeplugin.Response
+func (d *shimDriver) Capabilities() *volumeplugin.CapabilitiesResponse {
+	var res *volumeplugin.CapabilitiesResponse
 	res.Capabilities = volumeplugin.Capability{Scope: d.d.Scope()}
 	return res
 }

--- a/volume/shim/shim_test.go
+++ b/volume/shim/shim_test.go
@@ -37,16 +37,17 @@ func TestVolumeDriver(t *testing.T) {
 		Dial: l.Dial,
 	}}
 
-	resp, err := pluginRequest(client, "/VolumeDriver.Create", volumeplugin.Request{Name: "foo"})
+	resp, err := pluginRequest(client, "/VolumeDriver.Create", &volumeplugin.CreateRequest{Name: "foo"})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf(err.Error())
 	}
+
 	if resp.Err != "" {
 		t.Fatalf("error while creating volume: %v", err)
 	}
 }
 
-func pluginRequest(client *http.Client, method string, req volumeplugin.Request) (*volumeplugin.Response, error) {
+func pluginRequest(client *http.Client, method string, req *volumeplugin.CreateRequest) (*volumeplugin.ErrorResponse, error) {
 	b, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
@@ -55,7 +56,7 @@ func pluginRequest(client *http.Client, method string, req volumeplugin.Request)
 	if err != nil {
 		return nil, err
 	}
-	var vResp volumeplugin.Response
+	var vResp volumeplugin.ErrorResponse
 	err = json.NewDecoder(resp.Body).Decode(&vResp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This would fix https://github.com/docker/go-plugins-helpers/issues/41 and makes the usage of the volume API a little bit more clear. The volume API now has the same stile like the network API. (This PR probably breaks all existing Volume Plugins if they don't use a dependency mgmt. tool)

cc @dave-tucker 