### PR TITLE
support ConnectivityScope in network plugin

### DIFF
--- a/network/api.go
+++ b/network/api.go
@@ -50,7 +50,8 @@ type Driver interface {
 
 // CapabilitiesResponse returns whether or not this network is global or local
 type CapabilitiesResponse struct {
-	Scope string
+	Scope             string
+	ConnectivityScope string
 }
 
 // AllocateNetworkRequest requests allocation of new network by manager

--- a/network/api_test.go
+++ b/network/api_test.go
@@ -16,7 +16,7 @@ type TestDriver struct {
 }
 
 func (t *TestDriver) GetCapabilities() (*CapabilitiesResponse, error) {
-	return &CapabilitiesResponse{Scope: LocalScope}, nil
+	return &CapabilitiesResponse{Scope: LocalScope, ConnectivityScope: GlobalScope}, nil
 }
 
 func (t *TestDriver) CreateNetwork(r *CreateNetworkRequest) error {
@@ -128,7 +128,7 @@ func TestCapabilitiesExchange(t *testing.T) {
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
 
-	expected := `{"Scope":"local"}`
+	expected := `{"Scope":"local","ConnectivityScope":"global"}`
 	if string(body) != expected+"\n" {
 		t.Fatalf("Expected %s, got %s\n", expected+"\n", string(body))
 	}


### PR DESCRIPTION
due to the libnetwork remote api change in https://github.com/docker/libnetwork/commit/596122e05edd3e9712256ea309746ff903409446

Signed-off-by: bingshen.wbs <bingshen.wbs@alibaba-inc.com>