### PR TITLE
Don't use ReadAll in sdk.StreamResponse

### DIFF
--- a/sdk/encoder.go
+++ b/sdk/encoder.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -31,11 +30,8 @@ func EncodeResponse(w http.ResponseWriter, res interface{}, err string) {
 // StreamResponse streams a response object to the client
 func StreamResponse(w http.ResponseWriter, data io.ReadCloser) {
 	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
-	defer data.Close()
-	byteStream, err := ioutil.ReadAll(data)
-	if err != nil {
+	if _, err := copyBuf(w, data); err != nil {
 		fmt.Printf("ERROR in stream: %v\n", err)
-		return
 	}
-	w.Write(byteStream)
+	data.Close()
 }

--- a/sdk/pool.go
+++ b/sdk/pool.go
@@ -1,0 +1,18 @@
+package sdk
+
+import (
+	"io"
+	"sync"
+)
+
+const buffer32K = 32 * 1024
+
+var buffer32KPool = &sync.Pool{New: func() interface{} { return make([]byte, buffer32K) }}
+
+// copyBuf uses a shared buffer pool with io.CopyBuffer
+func copyBuf(w io.Writer, r io.Reader) (int64, error) {
+	buf := buffer32KPool.Get().([]byte)
+	written, err := io.CopyBuffer(w, r, buf)
+	buffer32KPool.Put(buf)
+	return written, err
+}


### PR DESCRIPTION
`ReadAll` could be reading lots of data, e.g. an image layer.
We also don't want to just use `io.Copy` which will allocate a new
buffer on each call, but instead use a shared buffer pool.

ping @samoht 