### PR TITLE
plugable secret backend

### DIFF
--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,31 @@
+# Docker secrets extension API
+
+Go handler to get secrets from external secret stores in Docker.
+
+## Usage
+
+This library is designed to be integrated in your program.
+
+1. Implement the `secrets.Driver` interface.
+2. Initialize a `secrets.Handler` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `secrets.Handler`.
+
+### Example using TCP sockets:
+
+```go
+  import "github.com/docker/go-plugins-helpers/secrets"
+
+  d := MySecretsDriver{}
+  h := secrets.NewHandler(d)
+  h.ServeTCP("test_secrets", ":8080")
+```
+
+### Example using Unix sockets:
+
+```go
+  import "github.com/docker/go-plugins-helpers/secrets"
+
+  d := MySecretsDriver{}
+  h := secrets.NewHandler(d)
+  h.ServeUnix("test_secrets", 0)
+```

--- a/secrets/api.go
+++ b/secrets/api.go
@@ -1,0 +1,74 @@
+package secrets
+
+import (
+	"github.com/docker/go-plugins-helpers/sdk"
+	"net/http"
+)
+
+const (
+	manifest = `{"Implements": ["secretprovider"]}`
+	getPath  = "/SecretProvider.GetSecret"
+)
+
+// Request is the plugin secret request
+type Request struct {
+	SecretName          string            `json:",omitempty"` // SecretName is the name of the secret to request from the plugin
+	ServiceHostname     string            `json:",omitempty"` // ServiceHostname is the hostname of the service, can be used for x509 certificate
+	ServiceName         string            `json:",omitempty"` // ServiceName is the name of the service that requested the secret
+	ServiceLabels       map[string]string `json:",omitempty"` // ServiceLabels capture environment names and other metadata
+	ServiceEndpointSpec *EndpointSpec     `json:",omitempty"` // ServiceEndpointSpec holds the specification for endpoints
+}
+
+// Response contains the plugin secret value
+type Response struct {
+	Value []byte `json:",omitempty"` // Value is the value of the secret
+	Err   string `json:",omitempty"` // Err is the error response of the plugin
+}
+
+// EndpointSpec represents the spec of an endpoint.
+type EndpointSpec struct {
+	Mode  int32        `json:",omitempty"`
+	Ports []PortConfig `json:",omitempty"`
+}
+
+// PortConfig represents the config of a port.
+type PortConfig struct {
+	Name     string `json:",omitempty"`
+	Protocol int32  `json:",omitempty"`
+	// TargetPort is the port inside the container
+	TargetPort uint32 `json:",omitempty"`
+	// PublishedPort is the port on the swarm hosts
+	PublishedPort uint32 `json:",omitempty"`
+	// PublishMode is the mode in which port is published
+	PublishMode int32 `json:",omitempty"`
+}
+
+// Driver represent the interface a driver must fulfill.
+type Driver interface {
+	// Get gets a secret from a remote secret store
+	Get(Request) Response
+}
+
+// Handler forwards requests and responses between the docker daemon and the plugin.
+type Handler struct {
+	driver Driver
+	sdk.Handler
+}
+
+// NewHandler initializes the request handler with a driver implementation.
+func NewHandler(driver Driver) *Handler {
+	h := &Handler{driver, sdk.NewHandler(manifest)}
+	h.initMux()
+	return h
+}
+
+func (h *Handler) initMux() {
+	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+		var req Request
+		if err := sdk.DecodeRequest(w, r, &req); err != nil {
+			return
+		}
+		res := h.driver.Get(req)
+		sdk.EncodeResponse(w, res, res.Err)
+	})
+}

--- a/secrets/api_test.go
+++ b/secrets/api_test.go
@@ -1,0 +1,78 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+func TestHandler(t *testing.T) {
+	p := &testPlugin{}
+	h := NewHandler(p)
+	l := sockets.NewInmemSocket("test", 0)
+	go h.Serve(l)
+	defer l.Close()
+
+	client := &http.Client{Transport: &http.Transport{
+		Dial: l.Dial,
+	}}
+
+	resp, err := pluginRequest(client, getPath, Request{SecretName: "my-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Err != "" {
+		t.Fatalf("error while getting secret: %v", resp.Err)
+	}
+	if p.get != 1 {
+		t.Fatalf("expected get 1, got %d", p.get)
+	}
+	if !bytes.EqualFold(secret, resp.Value) {
+		t.Fatalf("expecting secret value %s, got %s", secret, resp.Value)
+	}
+	resp, err = pluginRequest(client, getPath, Request{SecretName: ""})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.get != 2 {
+		t.Fatalf("expected get 2, got %d", p.get)
+	}
+	if resp.Err == "" {
+		t.Fatalf("expected missing secret")
+	}
+}
+
+func pluginRequest(client *http.Client, method string, req Request) (*Response, error) {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var vResp Response
+	err = json.NewDecoder(resp.Body).Decode(&vResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vResp, nil
+}
+
+type testPlugin struct {
+	get int
+}
+
+var secret = []byte("secret")
+
+func (p *testPlugin) Get(req Request) Response {
+	p.get++
+	if req.SecretName == "" {
+		return Response{Err: "missing secret name"}
+	}
+	return Response{Value: secret}
+}


### PR DESCRIPTION
This commit introduces a pluggable secrets backend as implemented in:
1. docker/swarmkit@eebac27434d34708fac993f9f5181d106c5c2fae
2. docker/docker@08f7cf05268782a0dd8e4c41a4cc65fdf78d09f2
3. [Design](https://docs.google.com/document/d/1kNA6apIFAiaE9d96A2_rcEulVrglvq05zEXGdijSZac)

Signed-off-by: Liron Levin <liron@twistlock.com>