### PR TITLE
Import Request/Response struct from docker/docker/pkg/authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 install-deps:
 	@echo "+ $@"
 	@go get -u github.com/golang/lint/golint
-	@go get -d ./...
+	@go get -d -t ./...
 
 lint:
 	@echo "+ $@"

--- a/authorization/api.go
+++ b/authorization/api.go
@@ -1,24 +1,98 @@
 package authorization
 
 import (
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 
-	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/go-plugins-helpers/sdk"
 )
 
 const (
-	manifest = `{"Implements": ["` + authorization.AuthZApiImplements + `"]}`
-	reqPath  = "/" + authorization.AuthZApiRequest
-	resPath  = "/" + authorization.AuthZApiResponse
+	// AuthZApiRequest is the url for daemon request authorization
+	AuthZApiRequest = "AuthZPlugin.AuthZReq"
+
+	// AuthZApiResponse is the url for daemon response authorization
+	AuthZApiResponse = "AuthZPlugin.AuthZRes"
+
+	// AuthZApiImplements is the name of the interface all AuthZ plugins implement
+	AuthZApiImplements = "authz"
+
+	manifest = `{"Implements": ["` + AuthZApiImplements + `"]}`
+	reqPath  = "/" + AuthZApiRequest
+	resPath  = "/" + AuthZApiResponse
 )
 
-// Request is the structure that docker's requests are deserialized to.
-type Request authorization.Request
+// PeerCertificate is a wrapper around x509.Certificate which provides a sane
+// encoding/decoding to/from PEM format and JSON.
+type PeerCertificate x509.Certificate
 
-// Response is the strucutre that the plugin's responses are serialized to.
-type Response authorization.Response
+// MarshalJSON returns the JSON encoded pem bytes of a PeerCertificate.
+func (pc *PeerCertificate) MarshalJSON() ([]byte, error) {
+	b := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: pc.Raw})
+	return json.Marshal(b)
+}
+
+// UnmarshalJSON populates a new PeerCertificate struct from JSON data.
+func (pc *PeerCertificate) UnmarshalJSON(b []byte) error {
+	var buf []byte
+	if err := json.Unmarshal(b, &buf); err != nil {
+		return err
+	}
+	derBytes, _ := pem.Decode(buf)
+	c, err := x509.ParseCertificate(derBytes.Bytes)
+	if err != nil {
+		return err
+	}
+	*pc = PeerCertificate(*c)
+	return nil
+}
+
+// Request holds data required for authZ plugins
+type Request struct {
+	// User holds the user extracted by AuthN mechanism
+	User string `json:"User,omitempty"`
+
+	// UserAuthNMethod holds the mechanism used to extract user details (e.g., krb)
+	UserAuthNMethod string `json:"UserAuthNMethod,omitempty"`
+
+	// RequestMethod holds the HTTP method (GET/POST/PUT)
+	RequestMethod string `json:"RequestMethod,omitempty"`
+
+	// RequestUri holds the full HTTP uri (e.g., /v1.21/version)
+	RequestURI string `json:"RequestUri,omitempty"`
+
+	// RequestBody stores the raw request body sent to the docker daemon
+	RequestBody []byte `json:"RequestBody,omitempty"`
+
+	// RequestHeaders stores the raw request headers sent to the docker daemon
+	RequestHeaders map[string]string `json:"RequestHeaders,omitempty"`
+
+	// RequestPeerCertificates stores the request's TLS peer certificates in PEM format
+	RequestPeerCertificates []*PeerCertificate `json:"RequestPeerCertificates,omitempty"`
+
+	// ResponseStatusCode stores the status code returned from docker daemon
+	ResponseStatusCode int `json:"ResponseStatusCode,omitempty"`
+
+	// ResponseBody stores the raw response body sent from docker daemon
+	ResponseBody []byte `json:"ResponseBody,omitempty"`
+
+	// ResponseHeaders stores the response headers sent to the docker daemon
+	ResponseHeaders map[string]string `json:"ResponseHeaders,omitempty"`
+}
+
+// Response represents authZ plugin response
+type Response struct {
+	// Allow indicating whether the user is allowed or not
+	Allow bool `json:"Allow"`
+
+	// Msg stores the authorization message
+	Msg string `json:"Msg,omitempty"`
+
+	// Err stores a message in case there's an error
+	Err string `json:"Err,omitempty"`
+}
 
 // Plugin represent the interface a plugin must fulfill.
 type Plugin interface {

--- a/authorization/api_test.go
+++ b/authorization/api_test.go
@@ -1,14 +1,22 @@
 package authorization
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/go-plugins-helpers/sdk"
+	"github.com/stretchr/testify/require"
 )
 
 type TestPlugin struct {
@@ -127,6 +135,66 @@ func TestAuthZRes(t *testing.T) {
 	if r.Err != "" {
 		t.Fatal("Authorization Error should be empty")
 	}
+}
+
+func TestPeerCertificateMarshalJSON(t *testing.T) {
+	template := &x509.Certificate{
+		IsCA: true,
+		BasicConstraintsValid: true,
+		SubjectKeyId:          []byte{1, 2, 3},
+		SerialNumber:          big.NewInt(1234),
+		Subject: pkix.Name{
+			Country:      []string{"Earth"},
+			Organization: []string{"Mother Nature"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().AddDate(5, 5, 5),
+
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	// generate private key
+	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	publickey := &privatekey.PublicKey
+
+	// create a self-signed certificate. template = parent
+	var parent = template
+	raw, err := x509.CreateCertificate(rand.Reader, template, parent, publickey, privatekey)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(raw)
+	require.NoError(t, err)
+
+	var certs = []*x509.Certificate{cert}
+	addr := "www.authz.com/auth"
+	req, err := http.NewRequest("GET", addr, nil)
+	require.NoError(t, err)
+
+	req.RequestURI = addr
+	req.TLS = &tls.ConnectionState{}
+	req.TLS.PeerCertificates = certs
+	req.Header.Add("header", "value")
+
+	for _, c := range req.TLS.PeerCertificates {
+		pcObj := PeerCertificate(*c)
+
+		t.Run("Marshalling :", func(t *testing.T) {
+			raw, err = pcObj.MarshalJSON()
+			require.NotNil(t, raw)
+			require.Nil(t, err)
+		})
+
+		t.Run("UnMarshalling :", func(t *testing.T) {
+			err := pcObj.UnmarshalJSON(raw)
+			require.Nil(t, err)
+			require.Equal(t, "Earth", pcObj.Subject.Country[0])
+			require.Equal(t, true, pcObj.IsCA)
+
+		})
+
+	}
+
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
As for other plugin/driver in this repository, these struct should be
defined in without dependency to a `docker/docker` struct (especially
in `pkg/*` folder).

This move the definition of these structs in `authorization`, instead
of type aliasing, and thus removes dependency on `pkg/authorization`
from this package.

cc @dnephin @thaJeztah @vieux @cpuguy83 @dave-tucker @runcom 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>