### PR TITLE
Allow go idiomatic return of nil MountResponse, PathResponse and GetResponse on error for driver implementations

### DIFF
--- a/volume/api.go
+++ b/volume/api.go
@@ -185,7 +185,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Path(req)
 		if err != nil {
-			res.Err = err.Error()
+			msg := err.Error()
+			res = &PathResponse{Err: msg}
+			sdk.EncodeResponse(w, res, msg)
+			return
 		}
 		sdk.EncodeResponse(w, res, "")
 	})
@@ -198,7 +201,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Get(req)
 		if err != nil {
-			res.Err = err.Error()
+			msg := err.Error()
+			res = &GetResponse{Err: msg}
+			sdk.EncodeResponse(w, res, msg)
+			return
 		}
 		sdk.EncodeResponse(w, res, "")
 	})
@@ -221,7 +227,10 @@ func (h *Handler) initMux() {
 		log.Println("Entering go-plugins-helpers listPath")
 		res, err := h.driver.List()
 		if err != nil {
-			res.Err = err.Error()
+			msg := err.Error()
+			res = &ListResponse{Err: msg}
+			sdk.EncodeResponse(w, res, msg)
+			return
 		}
 		sdk.EncodeResponse(w, res, "")
 	})

--- a/volume/api_test.go
+++ b/volume/api_test.go
@@ -157,7 +157,7 @@ func (p *testPlugin) Get(req *GetRequest) (*GetResponse, error) {
 			return &GetResponse{Volume: &Volume{Name: v}}, nil
 		}
 	}
-	return &GetResponse{}, fmt.Errorf("no such volume")
+	return nil, fmt.Errorf("no such volume")
 }
 
 func (p *testPlugin) List() (*ListResponse, error) {
@@ -187,7 +187,7 @@ func (p *testPlugin) Path(req *PathRequest) (*PathResponse, error) {
 			return &PathResponse{}, nil
 		}
 	}
-	return &PathResponse{}, fmt.Errorf("no such volume")
+	return nil, fmt.Errorf("no such volume")
 }
 
 func (p *testPlugin) Mount(req *MountRequest) (*MountResponse, error) {
@@ -197,7 +197,7 @@ func (p *testPlugin) Mount(req *MountRequest) (*MountResponse, error) {
 			return &MountResponse{}, nil
 		}
 	}
-	return &MountResponse{}, fmt.Errorf("no such volume")
+	return nil, fmt.Errorf("no such volume")
 }
 
 func (p *testPlugin) Unmount(req *UnmountRequest) error {


### PR DESCRIPTION
An idiomatic go function returns `value, nil` or `nil, error` on error.

The current implementation requires that on error the implementer of a driver returns an empty response struct and an error. This PR allows to return an `nil, error` as one would expect, does not break tests or the API.

Currently:
```
return &GetResponse{}, errors.New("some error")
```

After PR:
```
return nil, errors.New("some error")
```

Further, the current API still works the same.