### PR TITLE
multiple refactors and fixes

### DIFF
--- a/authorization/api.go
+++ b/authorization/api.go
@@ -138,6 +138,6 @@ func (h *Handler) handle(name string, actionCall actionHandler) {
 
 		res := actionCall(req)
 
-		sdk.EncodeResponse(w, res, res.Err)
+		sdk.EncodeResponse(w, res, res.Err != "")
 	})
 }

--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -3,8 +3,6 @@ package graphdriver
 // See https://github.com/docker/docker/blob/master/experimental/plugins_graphdriver.md
 
 import (
-	"bytes"
-	"encoding/json"
 	"io"
 	"net/http"
 
@@ -45,11 +43,6 @@ type InitRequest struct {
 	GIDMaps []idtools.IDMap `json:"GIDMaps"`
 }
 
-// InitResponse is the strucutre that docker's init responses are serialized to.
-type InitResponse struct {
-	Err string
-}
-
 // Create
 
 // CreateRequest is the structure that docker's create requests are deserialized to.
@@ -60,21 +53,11 @@ type CreateRequest struct {
 	StorageOpt map[string]string
 }
 
-// CreateResponse is the strucutre that docker's create responses are serialized to.
-type CreateResponse struct {
-	Err string
-}
-
 // Remove
 
 // RemoveRequest is the structure that docker's remove requests are deserialized to.
 type RemoveRequest struct {
 	ID string
-}
-
-// RemoveResponse is the strucutre that docker's remove responses are serialized to.
-type RemoveResponse struct {
-	Err string
 }
 
 // Get
@@ -88,7 +71,6 @@ type GetRequest struct {
 // GetResponse is the strucutre that docker's remove responses are serialized to.
 type GetResponse struct {
 	Dir string
-	Err string
 }
 
 // Put
@@ -96,11 +78,6 @@ type GetResponse struct {
 // PutRequest is the structure that docker's put requests are deserialized to.
 type PutRequest struct {
 	ID string
-}
-
-// PutResponse is the strucutre that docker's put responses are serialized to.
-type PutResponse struct {
-	Err string
 }
 
 // Exists
@@ -135,18 +112,12 @@ type GetMetadataRequest struct {
 // GetMetadataResponse is the structure that docker's getMetadata responses are serialized to.
 type GetMetadataResponse struct {
 	Metadata map[string]string
-	Err      string
 }
 
 // Cleanup
 
 // CleanupRequest is the structure that docker's cleanup requests are deserialized to.
 type CleanupRequest struct{}
-
-// CleanupResponse is the structure that docker's cleanup responses are serialized to.
-type CleanupResponse struct {
-	Err string
-}
 
 // Diff
 
@@ -172,7 +143,6 @@ type ChangesRequest struct {
 // ChangesResponse is the structure that docker's changes responses are serialized to.
 type ChangesResponse struct {
 	Changes []Change
-	Err     string
 }
 
 // ChangeKind represents the type of change mage
@@ -205,7 +175,6 @@ type ApplyDiffRequest struct {
 // ApplyDiffResponse is the structure that docker's applyDiff responses are serialized to.
 type ApplyDiffResponse struct {
 	Size int64
-	Err  string
 }
 
 // DiffSize
@@ -219,7 +188,6 @@ type DiffSizeRequest struct {
 // DiffSizeResponse is the structure that docker's diffSize responses are serialized to.
 type DiffSizeResponse struct {
 	Size int64
-	Err  string
 }
 
 // CapabilitiesRequest is the structure that docker's capabilities requests are deserialized to.
@@ -228,6 +196,16 @@ type CapabilitiesRequest struct{}
 // CapabilitiesResponse is the structure that docker's capabilities responses are serialized to.
 type CapabilitiesResponse struct {
 	Capabilities graphDriver.Capabilities
+}
+
+// ErrorResponse is a formatted error message that docker can understand
+type ErrorResponse struct {
+	Err string
+}
+
+// NewErrorResponse creates an ErrorResponse with the provided message
+func NewErrorResponse(msg string) *ErrorResponse {
+	return &ErrorResponse{Err: msg}
 }
 
 // Driver represent the interface a driver must fulfill.
@@ -270,11 +248,11 @@ func (h *Handler) initMux() {
 			return
 		}
 		err = h.driver.Init(req.Home, req.Options, req.UIDMaps, req.GIDMaps)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &InitResponse{Err: msg}, msg != "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(createPath, func(w http.ResponseWriter, r *http.Request) {
 		req := CreateRequest{}
@@ -283,11 +261,11 @@ func (h *Handler) initMux() {
 			return
 		}
 		err = h.driver.Create(req.ID, req.Parent, req.MountLabel, req.StorageOpt)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &CreateResponse{Err: msg}, msg != "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(createRWPath, func(w http.ResponseWriter, r *http.Request) {
 		req := CreateRequest{}
@@ -296,11 +274,11 @@ func (h *Handler) initMux() {
 			return
 		}
 		err = h.driver.CreateReadWrite(req.ID, req.Parent, req.MountLabel, req.StorageOpt)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &CreateResponse{Err: msg}, msg != "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
 		req := RemoveRequest{}
@@ -309,11 +287,11 @@ func (h *Handler) initMux() {
 			return
 		}
 		err = h.driver.Remove(req.ID)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &RemoveResponse{Err: msg}, msg != "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 
 	})
 	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
@@ -323,11 +301,11 @@ func (h *Handler) initMux() {
 			return
 		}
 		dir, err := h.driver.Get(req.ID, req.MountLabel)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &GetResponse{Err: msg, Dir: dir}, msg != "")
+		sdk.EncodeResponse(w, &GetResponse{Dir: dir}, false)
 	})
 	h.HandleFunc(putPath, func(w http.ResponseWriter, r *http.Request) {
 		req := PutRequest{}
@@ -336,11 +314,11 @@ func (h *Handler) initMux() {
 			return
 		}
 		err = h.driver.Put(req.ID)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &PutResponse{Err: msg}, msg != "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(existsPath, func(w http.ResponseWriter, r *http.Request) {
 		req := ExistsRequest{}
@@ -362,19 +340,19 @@ func (h *Handler) initMux() {
 			return
 		}
 		metadata, err := h.driver.GetMetadata(req.ID)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &GetMetadataResponse{Err: msg, Metadata: metadata}, msg != "")
+		sdk.EncodeResponse(w, &GetMetadataResponse{Metadata: metadata}, false)
 	})
 	h.HandleFunc(cleanupPath, func(w http.ResponseWriter, r *http.Request) {
 		err := h.driver.Cleanup()
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &CleanupResponse{Err: msg}, msg != "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(diffPath, func(w http.ResponseWriter, r *http.Request) {
 		req := DiffRequest{}
@@ -392,22 +370,22 @@ func (h *Handler) initMux() {
 			return
 		}
 		changes, err := h.driver.Changes(req.ID, req.Parent)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &ChangesResponse{Err: msg, Changes: changes}, msg != "")
+		sdk.EncodeResponse(w, &ChangesResponse{Changes: changes}, false)
 	})
 	h.HandleFunc(applyDiffPath, func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 		id := params.Get("id")
 		parent := params.Get("parent")
 		size, err := h.driver.ApplyDiff(id, parent, r.Body)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &ApplyDiffResponse{Err: msg, Size: size}, msg != "")
+		sdk.EncodeResponse(w, &ApplyDiffResponse{Size: size}, false)
 	})
 	h.HandleFunc(diffSizePath, func(w http.ResponseWriter, r *http.Request) {
 		req := DiffRequest{}
@@ -416,308 +394,14 @@ func (h *Handler) initMux() {
 			return
 		}
 		size, err := h.driver.DiffSize(req.ID, req.Parent)
-		msg := ""
 		if err != nil {
-			msg = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, &DiffSizeResponse{Err: msg, Size: size}, msg != "")
+		sdk.EncodeResponse(w, &DiffSizeResponse{Size: size}, false)
 	})
 	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
 		caps := h.driver.Capabilities()
 		sdk.EncodeResponse(w, &CapabilitiesResponse{Capabilities: caps}, false)
 	})
-}
-
-// CallInit is the raw call to the Graphdriver.Init method
-func CallInit(url string, client *http.Client, req InitRequest) (*InitResponse, error) {
-	method := initPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp InitResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallCreateReadWrite is the raw call to the Graphdriver.CreateReadWrite method
-func CallCreateReadWrite(url string, client *http.Client, req CreateRequest) (*CreateResponse, error) {
-	method := createRWPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp CreateResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallCreate is the raw call to the Graphdriver.Create method
-func CallCreate(url string, client *http.Client, req CreateRequest) (*CreateResponse, error) {
-	method := createPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp CreateResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallRemove is the raw call to the Graphdriver.Remove method
-func CallRemove(url string, client *http.Client, req RemoveRequest) (*RemoveResponse, error) {
-	method := removePath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp RemoveResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallGet is the raw call to the Graphdriver.Get method
-func CallGet(url string, client *http.Client, req GetRequest) (*GetResponse, error) {
-	method := getPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp GetResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallPut is the raw call to the Graphdriver.Put method
-func CallPut(url string, client *http.Client, req PutRequest) (*PutResponse, error) {
-	method := putPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp PutResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallExists is the raw call to the Graphdriver.Exists method
-func CallExists(url string, client *http.Client, req ExistsRequest) (*ExistsResponse, error) {
-	method := existsPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp ExistsResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallStatus is the raw call to the Graphdriver.Status method
-func CallStatus(url string, client *http.Client, req StatusRequest) (*StatusResponse, error) {
-	method := statusPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp StatusResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallGetMetadata is the raw call to the Graphdriver.GetMetadata method
-func CallGetMetadata(url string, client *http.Client, req GetMetadataRequest) (*GetMetadataResponse, error) {
-	method := getMetadataPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp GetMetadataResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallCleanup is the raw call to the Graphdriver.Cleanup method
-func CallCleanup(url string, client *http.Client, req CleanupRequest) (*CleanupResponse, error) {
-	method := cleanupPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp CleanupResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallDiff is the raw call to the Graphdriver.Diff method
-func CallDiff(url string, client *http.Client, req DiffRequest) (*DiffResponse, error) {
-	method := diffPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	return &DiffResponse{Stream: resp.Body}, nil
-}
-
-// CallChanges is the raw call to the Graphdriver.Changes method
-func CallChanges(url string, client *http.Client, req ChangesRequest) (*ChangesResponse, error) {
-	method := changesPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp ChangesResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallApplyDiff is the raw call to the Graphdriver.ApplyDiff method
-func CallApplyDiff(url string, client *http.Client, req ApplyDiffRequest) (*ApplyDiffResponse, error) {
-	method := applyDiffPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp ApplyDiffResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallDiffSize is the raw call to the Graphdriver.CallDiffSize method
-func CallDiffSize(url string, client *http.Client, req DiffSizeRequest) (*DiffSizeResponse, error) {
-	method := diffSizePath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp DiffSizeResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
-}
-
-// CallCapabilities is the raw call to the Graphdriver.Capabilities method
-func CallCapabilities(url string, client *http.Client, req CapabilitiesRequest) (*CapabilitiesResponse, error) {
-	method := capabilitiesPath
-	b, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Post(url+method, "application/json", bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	var vResp CapabilitiesResponse
-	err = json.NewDecoder(resp.Body).Decode(&vResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vResp, nil
 }

--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -274,7 +274,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &InitResponse{Err: msg}, msg)
+		sdk.EncodeResponse(w, &InitResponse{Err: msg}, msg != "")
 	})
 	h.HandleFunc(createPath, func(w http.ResponseWriter, r *http.Request) {
 		req := CreateRequest{}
@@ -287,7 +287,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &CreateResponse{Err: msg}, msg)
+		sdk.EncodeResponse(w, &CreateResponse{Err: msg}, msg != "")
 	})
 	h.HandleFunc(createRWPath, func(w http.ResponseWriter, r *http.Request) {
 		req := CreateRequest{}
@@ -300,7 +300,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &CreateResponse{Err: msg}, msg)
+		sdk.EncodeResponse(w, &CreateResponse{Err: msg}, msg != "")
 	})
 	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
 		req := RemoveRequest{}
@@ -313,7 +313,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &RemoveResponse{Err: msg}, msg)
+		sdk.EncodeResponse(w, &RemoveResponse{Err: msg}, msg != "")
 
 	})
 	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
@@ -327,7 +327,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &GetResponse{Err: msg, Dir: dir}, msg)
+		sdk.EncodeResponse(w, &GetResponse{Err: msg, Dir: dir}, msg != "")
 	})
 	h.HandleFunc(putPath, func(w http.ResponseWriter, r *http.Request) {
 		req := PutRequest{}
@@ -340,7 +340,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &PutResponse{Err: msg}, msg)
+		sdk.EncodeResponse(w, &PutResponse{Err: msg}, msg != "")
 	})
 	h.HandleFunc(existsPath, func(w http.ResponseWriter, r *http.Request) {
 		req := ExistsRequest{}
@@ -349,11 +349,11 @@ func (h *Handler) initMux() {
 			return
 		}
 		exists := h.driver.Exists(req.ID)
-		sdk.EncodeResponse(w, &ExistsResponse{Exists: exists}, "")
+		sdk.EncodeResponse(w, &ExistsResponse{Exists: exists}, false)
 	})
 	h.HandleFunc(statusPath, func(w http.ResponseWriter, r *http.Request) {
 		status := h.driver.Status()
-		sdk.EncodeResponse(w, &StatusResponse{Status: status}, "")
+		sdk.EncodeResponse(w, &StatusResponse{Status: status}, false)
 	})
 	h.HandleFunc(getMetadataPath, func(w http.ResponseWriter, r *http.Request) {
 		req := GetMetadataRequest{}
@@ -366,7 +366,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &GetMetadataResponse{Err: msg, Metadata: metadata}, msg)
+		sdk.EncodeResponse(w, &GetMetadataResponse{Err: msg, Metadata: metadata}, msg != "")
 	})
 	h.HandleFunc(cleanupPath, func(w http.ResponseWriter, r *http.Request) {
 		err := h.driver.Cleanup()
@@ -374,7 +374,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &CleanupResponse{Err: msg}, msg)
+		sdk.EncodeResponse(w, &CleanupResponse{Err: msg}, msg != "")
 	})
 	h.HandleFunc(diffPath, func(w http.ResponseWriter, r *http.Request) {
 		req := DiffRequest{}
@@ -396,7 +396,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &ChangesResponse{Err: msg, Changes: changes}, msg)
+		sdk.EncodeResponse(w, &ChangesResponse{Err: msg, Changes: changes}, msg != "")
 	})
 	h.HandleFunc(applyDiffPath, func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
@@ -407,7 +407,7 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &ApplyDiffResponse{Err: msg, Size: size}, msg)
+		sdk.EncodeResponse(w, &ApplyDiffResponse{Err: msg, Size: size}, msg != "")
 	})
 	h.HandleFunc(diffSizePath, func(w http.ResponseWriter, r *http.Request) {
 		req := DiffRequest{}
@@ -420,11 +420,11 @@ func (h *Handler) initMux() {
 		if err != nil {
 			msg = err.Error()
 		}
-		sdk.EncodeResponse(w, &DiffSizeResponse{Err: msg, Size: size}, msg)
+		sdk.EncodeResponse(w, &DiffSizeResponse{Err: msg, Size: size}, msg != "")
 	})
 	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
 		caps := h.driver.Capabilities()
-		sdk.EncodeResponse(w, &CapabilitiesResponse{Capabilities: caps}, "")
+		sdk.EncodeResponse(w, &CapabilitiesResponse{Capabilities: caps}, false)
 	})
 }
 

--- a/graphdriver/shim/shim_test.go
+++ b/graphdriver/shim/shim_test.go
@@ -1,6 +1,8 @@
 package shim
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -56,8 +58,6 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	return d, nil
 }
 
-const url = "http://localhost"
-
 func TestGraphDriver(t *testing.T) {
 	h := NewHandlerFromGraphDriver(Init)
 	l := sockets.NewInmemSocket("test", 0)
@@ -68,11 +68,29 @@ func TestGraphDriver(t *testing.T) {
 		Dial: l.Dial,
 	}}
 
-	resp, err := graphPlugin.CallInit(url, client, graphPlugin.InitRequest{Home: "foo"})
+	resp, err := pluginRequest(client, "/GraphDriver.Init", &graphPlugin.InitRequest{Home: "foo"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resp.Err != "" {
 		t.Fatalf("error while creating GraphDriver: %v", err)
 	}
+}
+
+func pluginRequest(client *http.Client, method string, req *graphPlugin.InitRequest) (*graphPlugin.ErrorResponse, error) {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Post("http://localhost"+method, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var gResp graphPlugin.ErrorResponse
+	err = json.NewDecoder(resp.Body).Decode(&gResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gResp, nil
 }

--- a/ipam/api.go
+++ b/ipam/api.go
@@ -105,20 +105,18 @@ func (h *Handler) initMux() {
 	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
 		res, err := h.ipam.GetCapabilities()
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(addressSpacesPath, func(w http.ResponseWriter, r *http.Request) {
 		res, err := h.ipam.GetDefaultAddressSpaces()
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(requestPoolPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &RequestPoolRequest{}
@@ -128,11 +126,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.ipam.RequestPool(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(releasePoolPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &ReleasePoolRequest{}
@@ -142,11 +139,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.ipam.ReleasePool(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(requestAddressPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &RequestAddressRequest{}
@@ -156,11 +152,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.ipam.RequestAddress(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(releaseAddressPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &ReleaseAddressRequest{}
@@ -170,9 +165,9 @@ func (h *Handler) initMux() {
 		}
 		err = h.ipam.ReleaseAddress(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 }

--- a/network/api.go
+++ b/network/api.go
@@ -223,16 +223,14 @@ func (h *Handler) initMux() {
 	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
 		res, err := h.driver.GetCapabilities()
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
 		if res == nil {
-			msg := "Network driver must implement GetCapabilities"
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse("Network driver must implement GetCapabilities"), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(createNetworkPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers createnetwork")
@@ -243,11 +241,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.CreateNetwork(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(allocateNetworkPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers allocatenetwork")
@@ -258,11 +255,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.AllocateNetwork(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(deleteNetworkPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &DeleteNetworkRequest{}
@@ -272,11 +268,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.DeleteNetwork(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(freeNetworkPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &FreeNetworkRequest{}
@@ -286,11 +281,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.FreeNetwork(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(createEndpointPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &CreateEndpointRequest{}
@@ -300,11 +294,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.CreateEndpoint(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(deleteEndpointPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &DeleteEndpointRequest{}
@@ -314,11 +307,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.DeleteEndpoint(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(endpointInfoPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &InfoRequest{}
@@ -328,10 +320,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.EndpointInfo(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(joinPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &JoinRequest{}
@@ -341,10 +333,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Join(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(leavePath, func(w http.ResponseWriter, r *http.Request) {
 		req := &LeaveRequest{}
@@ -354,11 +346,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.Leave(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(discoverNewPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &DiscoveryNotification{}
@@ -368,11 +359,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.DiscoverNew(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(discoverDeletePath, func(w http.ResponseWriter, r *http.Request) {
 		req := &DiscoveryNotification{}
@@ -382,11 +372,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.DiscoverDelete(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(programExtConnPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &ProgramExternalConnectivityRequest{}
@@ -396,11 +385,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.ProgramExternalConnectivity(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(revokeExtConnPath, func(w http.ResponseWriter, r *http.Request) {
 		req := &RevokeExternalConnectivityRequest{}
@@ -410,10 +398,9 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.RevokeExternalConnectivity(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, make(map[string]string), "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 }

--- a/sdk/encoder.go
+++ b/sdk/encoder.go
@@ -19,9 +19,9 @@ func DecodeRequest(w http.ResponseWriter, r *http.Request, req interface{}) (err
 }
 
 // EncodeResponse encodes the given structure into an http response.
-func EncodeResponse(w http.ResponseWriter, res interface{}, err string) {
+func EncodeResponse(w http.ResponseWriter, res interface{}, err bool) {
 	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
-	if err != "" {
+	if err {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	json.NewEncoder(w).Encode(res)

--- a/volume/api.go
+++ b/volume/api.go
@@ -42,7 +42,6 @@ type MountRequest struct {
 // MountResponse structure for a volume mount response
 type MountResponse struct {
 	Mountpoint string
-	Err        string
 }
 
 // UnmountRequest structure for a volume unmount request
@@ -59,7 +58,6 @@ type PathRequest struct {
 // PathResponse structure for a volume path response
 type PathResponse struct {
 	Mountpoint string
-	Err        string
 }
 
 // GetRequest structure for a volume get request
@@ -69,19 +67,16 @@ type GetRequest struct {
 
 // GetResponse structure for a volume get response
 type GetResponse struct {
-	Err    string
 	Volume *Volume
 }
 
 // ListResponse structure for a volume list response
 type ListResponse struct {
-	Err     string
 	Volumes []*Volume
 }
 
 // CapabilitiesResponse structure for a volume capability response
 type CapabilitiesResponse struct {
-	Err          string
 	Capabilities Capability
 }
 
@@ -142,11 +137,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.Create(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
 			return
 		}
-		sdk.EncodeResponse(w, NewErrorResponse(""), "")
+		sdk.EncodeResponse(w, struct{}{}, "")
 	})
 	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers removePath")
@@ -157,11 +151,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.Remove(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
 			return
 		}
-		sdk.EncodeResponse(w, NewErrorResponse(""), "")
+		sdk.EncodeResponse(w, struct{}{}, "")
 	})
 	h.HandleFunc(mountPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers mountPath")
@@ -172,7 +165,8 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Mount(req)
 		if err != nil {
-			res.Err = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			return
 		}
 		sdk.EncodeResponse(w, res, "")
 	})
@@ -185,7 +179,8 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Path(req)
 		if err != nil {
-			res.Err = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			return
 		}
 		sdk.EncodeResponse(w, res, "")
 	})
@@ -198,7 +193,8 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Get(req)
 		if err != nil {
-			res.Err = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			return
 		}
 		sdk.EncodeResponse(w, res, "")
 	})
@@ -211,17 +207,17 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.Unmount(req)
 		if err != nil {
-			msg := err.Error()
-			sdk.EncodeResponse(w, NewErrorResponse(msg), msg)
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
 			return
 		}
-		sdk.EncodeResponse(w, NewErrorResponse(""), "")
+		sdk.EncodeResponse(w, struct{}{}, "")
 	})
 	h.HandleFunc(listPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers listPath")
 		res, err := h.driver.List()
 		if err != nil {
-			res.Err = err.Error()
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			return
 		}
 		sdk.EncodeResponse(w, res, "")
 	})

--- a/volume/api.go
+++ b/volume/api.go
@@ -137,10 +137,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.Create(req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, struct{}{}, "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers removePath")
@@ -151,10 +151,10 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.Remove(req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, struct{}{}, "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(mountPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers mountPath")
@@ -165,10 +165,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Mount(req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(hostVirtualPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers hostVirtualPath")
@@ -179,10 +179,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Path(req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers getPath")
@@ -193,10 +193,10 @@ func (h *Handler) initMux() {
 		}
 		res, err := h.driver.Get(req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 	h.HandleFunc(unmountPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers unmountPath")
@@ -207,23 +207,23 @@ func (h *Handler) initMux() {
 		}
 		err = h.driver.Unmount(req)
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, struct{}{}, "")
+		sdk.EncodeResponse(w, struct{}{}, false)
 	})
 	h.HandleFunc(listPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers listPath")
 		res, err := h.driver.List()
 		if err != nil {
-			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), "true")
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
 			return
 		}
-		sdk.EncodeResponse(w, res, "")
+		sdk.EncodeResponse(w, res, false)
 	})
 
 	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Entering go-plugins-helpers capabilitiesPath")
-		sdk.EncodeResponse(w, h.driver.Capabilities(), "")
+		sdk.EncodeResponse(w, h.driver.Capabilities(), false)
 	})
 }

--- a/volume/api_test.go
+++ b/volume/api_test.go
@@ -24,7 +24,6 @@ func TestHandler(t *testing.T) {
 
 	// Create
 	_, err := pluginRequest(client, createPath, &CreateRequest{Name: "foo"})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,9 +37,6 @@ func TestHandler(t *testing.T) {
 	if err := json.NewDecoder(resp).Decode(&gResp); err != nil {
 		t.Fatal(err)
 	}
-	if gResp.Err != "" {
-		t.Fatalf("got error getting volume: %s", gResp.Err)
-	}
 	if gResp.Volume.Name != "foo" {
 		t.Fatalf("expected volume `foo`, got %v", gResp.Volume)
 	}
@@ -53,9 +49,6 @@ func TestHandler(t *testing.T) {
 	var lResp *ListResponse
 	if err := json.NewDecoder(resp).Decode(&lResp); err != nil {
 		t.Fatal(err)
-	}
-	if lResp.Err != "" {
-		t.Fatalf("expected no volume, got: %s", lResp.Err)
 	}
 	if len(lResp.Volumes) != 1 {
 		t.Fatalf("expected 1 volume, got %v", lResp.Volumes)
@@ -105,10 +98,6 @@ func TestHandler(t *testing.T) {
 	var cResp *CapabilitiesResponse
 	if err := json.NewDecoder(resp).Decode(&cResp); err != nil {
 		t.Fatal(err)
-	}
-
-	if cResp.Err != "" {
-		t.Fatalf("got error removing volume: %s", cResp.Err)
 	}
 
 	if p.capabilities != 1 {

--- a/volume/api_test.go
+++ b/volume/api_test.go
@@ -33,6 +33,9 @@ func TestHandler(t *testing.T) {
 
 	// Get
 	resp, err := pluginRequest(client, getPath, &GetRequest{Name: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	var gResp *GetResponse
 	if err := json.NewDecoder(resp).Decode(&gResp); err != nil {
 		t.Fatal(err)
@@ -46,6 +49,9 @@ func TestHandler(t *testing.T) {
 
 	// List
 	resp, err = pluginRequest(client, listPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var lResp *ListResponse
 	if err := json.NewDecoder(resp).Decode(&lResp); err != nil {
 		t.Fatal(err)

--- a/volume/shim/shim.go
+++ b/volume/shim/shim.go
@@ -27,7 +27,6 @@ func (d *shimDriver) List() (*volumeplugin.ListResponse, error) {
 	var res *volumeplugin.ListResponse
 	ls, err := d.d.List()
 	if err != nil {
-		res.Err = err.Error()
 		return &volumeplugin.ListResponse{}, err
 	}
 	vols := make([]*volumeplugin.Volume, len(ls))
@@ -47,7 +46,6 @@ func (d *shimDriver) Get(req *volumeplugin.GetRequest) (*volumeplugin.GetRespons
 	var res *volumeplugin.GetResponse
 	v, err := d.d.Get(req.Name)
 	if err != nil {
-		res.Err = err.Error()
 		return &volumeplugin.GetResponse{}, err
 	}
 	res.Volume = &volumeplugin.Volume{
@@ -73,8 +71,7 @@ func (d *shimDriver) Path(req *volumeplugin.PathRequest) (*volumeplugin.PathResp
 	var res *volumeplugin.PathResponse
 	v, err := d.d.Get(req.Name)
 	if err != nil {
-		res.Err = err.Error()
-		return res, err
+		return &volumeplugin.PathResponse{}, err
 	}
 	res.Mountpoint = v.Path()
 	return res, nil
@@ -84,12 +81,11 @@ func (d *shimDriver) Mount(req *volumeplugin.MountRequest) (*volumeplugin.MountR
 	var res *volumeplugin.MountResponse
 	v, err := d.d.Get(req.Name)
 	if err != nil {
-		res.Err = err.Error()
-		return res, err
+		return &volumeplugin.MountResponse{}, err
 	}
 	pth, err := v.Mount(req.ID)
 	if err != nil {
-		res.Err = err.Error()
+		return &volumeplugin.MountResponse{}, err
 	}
 	res.Mountpoint = pth
 	return res, nil


### PR DESCRIPTION
sorry it's a big PR, reading commit by commit could be helpful.
I started refactoring one side and then `¯\_(ツ)_/¯` started from https://github.com/docker/go-plugins-helpers/pull/76

The bunch of the refactor started from here.

some API (graphdriver) had a `Err` field in almost every Responses, and sometimes duplicated (empty) responses
some API (volume) had a `Err` field in *some* Responses and sometimes used `ErrorResponse`.
some API (network, ipam) had no `Err` and used a dedicated `ErrorResponse` for error.

Basically graphdriver and network/ipam were totally different and volume was in the middle.
I decided to uniform everything like network and ipam.

It also adds a bunch of fixes, such as adding missing multiple `return`


ping @cpuguy83 for some reason I cannot add you a reviewer.
