### PR TITLE
Make systemd socket activation actually work

### DIFF
--- a/sdk/unix_listener.go
+++ b/sdk/unix_listener.go
@@ -17,7 +17,13 @@ func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	listener, err := sockets.NewUnixSocket(path, gid)
+	// try systemd socket activation first
+	listener, err := setupSocketActivation()
+	if err == nil {
+		return listener, path, nil
+	}
+
+	listener, err = sockets.NewUnixSocket(path, gid)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
When trying socket activation for my Docker network plugin, I noticed
that the first request to the plugin never reached the plugin. As it
turns out, the relevant code for extracting the passed-in socket from
systemd never got called. I think this caused systemd to failover,
cede the socket and try running the plugin normally, but at that
point, docker already hangs.

Signed-off-by: Steffen Müthing <steffen.muething@iwr.uni-heidelberg.de>