### PR TITLE
Allow user socket addresses

### DIFF
--- a/sdk/unix_listener.go
+++ b/sdk/unix_listener.go
@@ -25,11 +25,11 @@ func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
 }
 
 func fullSocketAddress(address string) (string, error) {
-	if err := os.MkdirAll(pluginSockDir, 0755); err != nil {
-		return "", err
-	}
 	if filepath.IsAbs(address) {
 		return address, nil
+	}
+	if err := os.MkdirAll(pluginSockDir, 0755); err != nil {
+		return "", err
 	}
 	return filepath.Join(pluginSockDir, address+".sock"), nil
 }


### PR DESCRIPTION
Even if users don't have access to `/run/docker/plugins` they should be able to run a plugin with specified socket address.