### PR TITLE
Fix lint and compiler errors

### DIFF
--- a/graphdriver/shim/shim.go
+++ b/graphdriver/shim/shim.go
@@ -69,7 +69,8 @@ func (d *shimDriver) Get(id, mountLabel string) (string, error) {
 	if d == nil {
 		return "", errNotInitialized
 	}
-	return d.driver.Get(id, mountLabel)
+	res, err := d.driver.Get(id, mountLabel)
+	return res.Path(), err
 }
 
 func (d *shimDriver) Put(id string) error {

--- a/graphdriver/shim/shim_test.go
+++ b/graphdriver/shim/shim_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/docker/docker/pkg/containerfs"
+
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/go-connections/sockets"
@@ -31,8 +33,8 @@ func (t *testGraphDriver) Create(id, parent string, opts *graphdriver.CreateOpts
 func (t *testGraphDriver) Remove(id string) error {
 	return nil
 }
-func (t *testGraphDriver) Get(id, mountLabel string) (dir string, err error) {
-	return "", nil
+func (t *testGraphDriver) Get(id, mountLabel string) (dir containerfs.ContainerFS, err error) {
+	return nil, nil
 }
 func (t *testGraphDriver) Put(id string) error {
 	return nil

--- a/volume/shim/shim.go
+++ b/volume/shim/shim.go
@@ -61,10 +61,7 @@ func (d *shimDriver) Remove(req *volumeplugin.RemoveRequest) error {
 	if err != nil {
 		return err
 	}
-	if err := d.d.Remove(v); err != nil {
-		return err
-	}
-	return nil
+	return d.d.Remove(v)
 }
 
 func (d *shimDriver) Path(req *volumeplugin.PathRequest) (*volumeplugin.PathResponse, error) {
@@ -96,10 +93,7 @@ func (d *shimDriver) Unmount(req *volumeplugin.UnmountRequest) error {
 	if err != nil {
 		return err
 	}
-	if err := v.Unmount(req.ID); err != nil {
-		return err
-	}
-	return nil
+	return v.Unmount(req.ID)
 }
 
 func (d *shimDriver) Capabilities() *volumeplugin.CapabilitiesResponse {


### PR DESCRIPTION
This fixes the lint errors in the volume plugin and compilation errors after an interface change in the graphdriver