### PR TITLE
Added CreatedAt property to Volume struct

### DIFF
--- a/volume/api.go
+++ b/volume/api.go
@@ -84,6 +84,7 @@ type CapabilitiesResponse struct {
 type Volume struct {
 	Name       string
 	Mountpoint string
+	CreatedAt  string
 	Status     map[string]interface{}
 }
 


### PR DESCRIPTION
The CreatedAt property is missing from the Volume struct, this means docker volume inspect returns 
```
[
    {
        "CreatedAt": "0001-01-01T00:00:00Z",
        "Driver": "volume-driver-test:latest",
        "Labels": {},
        "Mountpoint": "/mnt/data/volumes/test",
        "Name": "test",
        "Options": {},
        "Scope": "global"
    }
]
```

Adding this and returning it fixes the problem.