### PR TITLE
adding 'json:omitempty' on optional Volume fields to avoid errors on Docker

### DIFF
--- a/volume/api.go
+++ b/volume/api.go
@@ -83,9 +83,9 @@ type CapabilitiesResponse struct {
 // Volume represents a volume object for use with `Get` and `List` requests
 type Volume struct {
 	Name       string
-	Mountpoint string
-	CreatedAt  string
-	Status     map[string]interface{}
+	Mountpoint string `json:",omitempty"`
+	CreatedAt  string `json:",omitempty"`
+	Status     map[string]interface{} `json:",omitempty"`
 }
 
 // Capability represents the list of capabilities a volume driver can return


### PR DESCRIPTION
I had a hard to find docker daemon error with the CreatedAt Volume field because go-plugins-helpers was encoding it even when the field was empty.

closes #108 