### PR TITLE
Inclusion of Nemo in the examples

### DIFF
--- a/volume/README.md
+++ b/volume/README.md
@@ -33,3 +33,4 @@ This library is designed to be integrated in your program.
 - https://github.com/calavera/docker-volume-glusterfs
 - https://github.com/calavera/docker-volume-keywhiz
 - https://github.com/quobyte/docker-volume
+- https://github.com/NimbleStorage/Nemo


### PR DESCRIPTION
Docker Volume plugin emulating the HPE Nimble Storage plugin on top of OpenZFS.