### PR TITLE
Add additional info for secret drivers

### DIFF
--- a/secrets/api.go
+++ b/secrets/api.go
@@ -14,9 +14,13 @@ const (
 // Request is the plugin secret request
 type Request struct {
 	SecretName          string            `json:",omitempty"` // SecretName is the name of the secret to request from the plugin
+	SecretLabels        map[string]string `json:",omitempty"` // SecretLabels capture environment names and other metadata pertaining to the secret
 	ServiceHostname     string            `json:",omitempty"` // ServiceHostname is the hostname of the service, can be used for x509 certificate
 	ServiceName         string            `json:",omitempty"` // ServiceName is the name of the service that requested the secret
-	ServiceLabels       map[string]string `json:",omitempty"` // ServiceLabels capture environment names and other metadata
+	ServiceID           string            `json:",omitempty"` // ServiceID is the name of the service that requested the secret
+	ServiceLabels       map[string]string `json:",omitempty"` // ServiceLabels capture environment names and other metadata pertaining to the service
+	TaskID              string            `json:",omitempty"` // TaskID is the ID of the task that the secret is assigned to
+	TaskName            string            `json:",omitempty"` // TaskName is the name of the task that the secret is assigned to
 	ServiceEndpointSpec *EndpointSpec     `json:",omitempty"` // ServiceEndpointSpec holds the specification for endpoints
 }
 

--- a/secrets/api.go
+++ b/secrets/api.go
@@ -21,6 +21,7 @@ type Request struct {
 	ServiceLabels       map[string]string `json:",omitempty"` // ServiceLabels capture environment names and other metadata pertaining to the service
 	TaskID              string            `json:",omitempty"` // TaskID is the ID of the task that the secret is assigned to
 	TaskName            string            `json:",omitempty"` // TaskName is the name of the task that the secret is assigned to
+	TaskImage           string            `json:",omitempty"` // TaskName is the image of the task that the secret is assigned to
 	ServiceEndpointSpec *EndpointSpec     `json:",omitempty"` // ServiceEndpointSpec holds the specification for endpoints
 }
 

--- a/secrets/api_test.go
+++ b/secrets/api_test.go
@@ -43,6 +43,16 @@ func TestHandler(t *testing.T) {
 	if resp.Err == "" {
 		t.Fatalf("expected missing secret")
 	}
+	resp, err = pluginRequest(client, getPath, Request{SecretName: "another-secret", SecretLabels: map[string]string{"prefix": "p-"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Err != "" {
+		t.Fatalf("error while getting secret: %v", resp.Err)
+	}
+	if !bytes.EqualFold(append([]byte("p-"), secret...), resp.Value) {
+		t.Fatalf("expecting secret value %s, got %s", secret, resp.Value)
+	}
 }
 
 func pluginRequest(client *http.Client, method string, req Request) (*Response, error) {
@@ -73,6 +83,9 @@ func (p *testPlugin) Get(req Request) Response {
 	p.get++
 	if req.SecretName == "" {
 		return Response{Err: "missing secret name"}
+	}
+	if prefix, exists := req.SecretLabels["prefix"]; exists {
+		return Response{Value: append([]byte(prefix), secret...)}
 	}
 	return Response{Value: secret}
 }


### PR DESCRIPTION
This provides more context for the secret driver when it is requested
the value for the secret. It is useful both for audit purposes, e.g. an
external system logging which task requested what secret, as well as
in a scenario where the plugin would return a different value (or
error) based on e.g. labels on the secret.

Blocks https://github.com/docker/swarmkit/pull/2738.

Signed-off-by: Sune Keller <absukl@almbrand.dk>