### PR TITLE
Fix documentation link

### DIFF
--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -1,6 +1,6 @@
 package graphdriver
 
-// See https://github.com/docker/docker/blob/master/experimental/plugins_graphdriver.md
+// See https://github.com/docker/cli/blob/master/docs/extend/plugins_graphdriver.md
 
 import (
 	"io"


### PR DESCRIPTION
Fix documentation link in API go file commentary due to files moved in moby/moby@677fa03654886ee776ff478c30681d5376cfc196 in 2016 and once more in moby/moby@b5579a4ce33af4c1f67118e11b5a01008a36d26a in 2017.