### PR TITLE
Replace github.com/docker/docker imports with github.com/moby/moby

### DIFF
--- a/graphdriver/api.go
+++ b/graphdriver/api.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"net/http"
 
-	graphDriver "github.com/docker/docker/daemon/graphdriver"
-	"github.com/docker/docker/pkg/containerfs"
-	"github.com/docker/docker/pkg/idtools"
+	graphDriver "github.com/moby/moby/daemon/graphdriver"
+	"github.com/moby/moby/pkg/containerfs"
+	"github.com/moby/moby/pkg/idtools"
 	"github.com/docker/go-plugins-helpers/sdk"
 )
 

--- a/graphdriver/api_test.go
+++ b/graphdriver/api_test.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"testing"
 
-	graphDriver "github.com/docker/docker/daemon/graphdriver"
-	"github.com/docker/docker/pkg/containerfs"
-	"github.com/docker/docker/pkg/idtools"
+	graphDriver "github.com/moby/moby/daemon/graphdriver"
+	"github.com/moby/moby/pkg/containerfs"
+	"github.com/moby/moby/pkg/idtools"
 	"github.com/docker/go-connections/sockets"
 )
 

--- a/graphdriver/shim/shim.go
+++ b/graphdriver/shim/shim.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"log"
 
-	graphDriver "github.com/docker/docker/daemon/graphdriver"
-	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/containerfs"
-	"github.com/docker/docker/pkg/idtools"
+	graphDriver "github.com/moby/moby/daemon/graphdriver"
+	"github.com/moby/moby/pkg/archive"
+	"github.com/moby/moby/pkg/containerfs"
+	"github.com/moby/moby/pkg/idtools"
 	graphPlugin "github.com/docker/go-plugins-helpers/graphdriver"
 )
 

--- a/graphdriver/shim/shim_test.go
+++ b/graphdriver/shim/shim_test.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/docker/docker/pkg/containerfs"
+	"github.com/moby/moby/pkg/containerfs"
 
-	"github.com/docker/docker/daemon/graphdriver"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/moby/daemon/graphdriver"
+	"github.com/moby/moby/pkg/idtools"
 	"github.com/docker/go-connections/sockets"
 	graphPlugin "github.com/docker/go-plugins-helpers/graphdriver"
 )

--- a/volume/shim/shim.go
+++ b/volume/shim/shim.go
@@ -1,7 +1,7 @@
 package shim
 
 import (
-	"github.com/docker/docker/volume"
+	"github.com/moby/moby/volume"
 	volumeplugin "github.com/docker/go-plugins-helpers/volume"
 )
 

--- a/volume/shim/shim_test.go
+++ b/volume/shim/shim_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/docker/docker/volume"
+	"github.com/moby/moby/volume"
 	"github.com/docker/go-connections/sockets"
 	volumeplugin "github.com/docker/go-plugins-helpers/volume"
 )


### PR DESCRIPTION
With `github.com/docker/docker` it seems like it is impossible to get version newer than v13.2, and the new name `github.com/moby/moby` has all versions history.