### PR TITLE
 Corrected default volumes root directory for Windows

### DIFF
--- a/volume/api.go
+++ b/volume/api.go
@@ -8,9 +8,6 @@ import (
 )
 
 const (
-	// DefaultDockerRootDirectory is the default directory where volumes will be created.
-	DefaultDockerRootDirectory = "/var/lib/docker-volumes"
-
 	manifest         = `{"Implements": ["VolumeDriver"]}`
 	createPath       = "/VolumeDriver.Create"
 	getPath          = "/VolumeDriver.Get"

--- a/volume/unix_api.go
+++ b/volume/unix_api.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package volume
+
+const (
+	// DefaultDockerRootDirectory is the default directory where volumes will be created.
+	DefaultDockerRootDirectory = "/var/lib/docker-volumes"
+)

--- a/volume/windows_api.go
+++ b/volume/windows_api.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package volume
+
+const (
+	// DefaultDockerRootDirectory is the default directory where volumes will be created.
+	DefaultDockerRootDirectory = `C:\ProgramData\docker-volumes`
+)


### PR DESCRIPTION
I noticed that Linux default volumes root directory was `/var/lib/docker-volumes` instead of `/var/lib/docker/volumes` so I corrected that one + added support for Windows version.