### PR TITLE
refresh maintainers list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,9 +11,13 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
-			"calavera",
-			"dave-tucker",
-			"runcom",
+			"akerouanton",
+			"laurazard",
+			"neersighted",
+			"robmry",
+			"rumpl",
+			"thajeztah",
+			"vvoland",
 		]
 
 [people]
@@ -23,17 +27,38 @@
 # in the people section.
 
 	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
-	[people.calavera]
-	Name = "David Calavera"
-	Email = "david.calavera@gmail.com"
-	GitHub = "calavera"
 
-	[people.dave-tucker]
-	Name = "Dave Tucker"
-	Email = "dt@docker.com"
-	GitHub = "dave-tucker"
+	[people.akerouanton]
+	Name = "Albin Kerouanton"
+	Email = "albinker@gmail.com"
+	GitHub = "akerouanton"
 
-	[people.runcom]
-	Name = "Antonio Murdaca"
-	Email = "runcom@redhat.com"
-	GitHub = "runcom"
+	[people.laurazard]
+	Name = "Laura Brehm"
+	Email = "laura.brehm@docker.com"
+	GitHub = "laurazard"
+
+	[people.neersighted]
+	Name = "Bjorn Neergaard"
+	Email = "bjorn@neersighted.com"
+	GitHub = "neersighted"
+
+	[people.robmry]
+	Name = "Rob Murray"
+	Email = "rob.murray@docker.com"
+	GitHub = "robmry"
+
+	[people.rumpl]
+	Name = "Djordje Lukic"
+	Email = "djordje.lukic@docker.com"
+	GitHub = "rumpl"
+
+	[people.thajeztah]
+	Name = "Sebastiaan van Stijn"
+	Email = "github@gone.nl"
+	GitHub = "thaJeztah"
+
+	[people.vvoland]
+	Name = "Paweł Gronowski"
+	Email = "pawel.gronowski@docker.com"
+	GitHub = "vvoland"


### PR DESCRIPTION
- [x] stacked on https://github.com/docker/go-plugins-helpers/pull/138
- closes https://github.com/docker/go-plugins-helpers/issues/132

### refresh maintainers list

This repository went not looked after for some time, and the
runtime team will be looking at refreshing it a bit.
